### PR TITLE
Fix upcoming holidays table heading

### DIFF
--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -88,7 +88,7 @@ const Province = ({
         <section>
           <${SummaryTable}
             id="upcoming-holidays"
-            title=${`Upcoming ${federal && 'federal'} holidays in ${provinceName}`}
+            title=${`Upcoming ${federal ? 'federal' : ''} holidays in ${provinceName}`}
             rows=${createRows(holidays, federal)}
           />
           <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>


### PR DESCRIPTION
Right now it says “false” if the holiday isn't federal (which looks quite amusing, in my opinion):

![image](https://user-images.githubusercontent.com/1298948/64345339-dc842e80-cff8-11e9-9fa0-e5f2b3e7805c.png)
