### PR TITLE
Add test for h1 and h2 on Province page

### DIFF
--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -88,7 +88,7 @@ const Province = ({
         <section>
           <${SummaryTable}
             id="upcoming-holidays"
-            title=${`Upcoming ${federal ? 'federal' : ''} holidays in ${provinceName}`}
+            title=${`Upcoming${federal ? ' federal' : ''} holidays in ${provinceName}`}
             rows=${createRows(holidays, federal)}
           />
           <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -1,0 +1,44 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils')
+
+const Province = require('../Province.js')
+
+const getProvince = () => {
+  return { id: 'PE', nameEn: 'Prince Edward Island' }
+}
+
+const getNextHoliday = () => {
+  return {
+    id: 20,
+    date: '2019-08-16',
+    nameEn: 'Gold Cup Parade Day',
+    federal: 0,
+    provinces: [getProvince()],
+  }
+}
+
+const renderPage = () => {
+  const _nextHoliday = getNextHoliday()
+  return cheerio.load(
+    render(
+      html`
+        <${Province} ...${{ data: { nextHoliday: _nextHoliday, holidays: [_nextHoliday] } }} />
+      `,
+    ),
+  )
+}
+
+//   data: { holidays, nextHoliday, provinceName = 'Canada', provinceId, federal = false } = {},
+
+describe('Province page', () => {
+  test('renders h1 and h2', () => {
+    const $ = renderPage({ nextHoliday: { nameEn: 'May Day' } })
+    expect($('h1').length).toBe(1)
+    expect($('h1').text()).toEqual(
+      'Canada’s next statutory holiday is Gold Cup Parade Day on August 16th',
+    )
+    expect($('h2').length).toBe(1)
+    expect($('h2').text()).toEqual('Upcoming holidays in Canada')
+  })
+})


### PR DESCRIPTION
@notpushkin noticed that I had a boolean condition in the Province page that would print "false" if the "federal" variable was false (instead of ignoring it).

Adding a test to sense-check this.