### PR TITLE
Change hardcoded "2019" to a variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 name: CI
-
 on: [push]
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/dates/index.js
+++ b/src/dates/index.js
@@ -44,7 +44,7 @@ const _parseRelativeDates = dateString => {
   return addDays(anchorDate, position * count)
 }
 
-const getISODate = (dateString, year = new Date().getUTCFullYear()) => {
+const getISODate = (dateString, year = new Date(Date.now()).getUTCFullYear()) => {
   let date
   dateString = `${dateString} ${year}`
 
@@ -80,7 +80,7 @@ const displayDate = (dateString, weekday = false) => {
 
 const relativeDate = dateString => {
   const daysOffset = differenceInDays(
-    startOfDay(new Date()),
+    startOfDay(new Date(Date.now())),
     getDateBeforeMidnightFromString(dateString),
   )
 
@@ -90,7 +90,10 @@ const relativeDate = dateString => {
     case -1:
       return 'That’s tomorrow!'
     default:
-      return `That’s in ${formatDistance(getDateBeforeMidnightFromString(dateString), new Date())}`
+      return `That’s in ${formatDistance(
+        getDateBeforeMidnightFromString(dateString),
+        new Date(Date.now()),
+      )}`
   }
 }
 

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -77,7 +77,7 @@ const createRows = (holidays, federal) => {
     )
   }
 
-  const today = new Date().toISOString().slice(0, 10)
+  const today = new Date(Date.now()).toISOString().slice(0, 10)
 
   return holidays.map(holiday => {
     const row = {
@@ -122,7 +122,7 @@ const Province = ({
         <section class=${horizontalPadding}>
           <div class=${insideContainer}>
             <${SummaryTable}
-              id=${`holidays-${year}`}
+              id="holidays-table"
               title=${createTitle(provinceName, federal, year)}
               rows=${createRows(holidays, federal)}
             >

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -65,7 +65,7 @@ const getNextHoliday = provinces => {
   provinces.map(province => {
     province.nextHoliday = province.holidays.find(holiday => {
       // compare iso strings: eg, "2019-09-04" >= "2019-08-04"
-      return holiday.date >= new Date().toISOString().substring(0, 10)
+      return holiday.date >= new Date(Date.now()).toISOString().substring(0, 10)
     })
   })
 }

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -212,7 +212,7 @@ describe('Test /api responses', () => {
 
       let badYears = ['2018', '2022', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map(year => {
-        test(`${year} it should return all holidays for ${new Date()
+        test(`${year} it should return all holidays for ${new Date(Date.now())
           .getUTCFullYear()
           .toString()} with the current year`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
@@ -221,7 +221,9 @@ describe('Test /api responses', () => {
           let { holidays } = JSON.parse(response.text)
 
           holidays.map(holiday => {
-            expect(holiday.date.slice(0, 4)).toEqual(new Date().getUTCFullYear().toString())
+            expect(holiday.date.slice(0, 4)).toEqual(
+              new Date(Date.now()).getUTCFullYear().toString(),
+            )
           })
         })
       })
@@ -279,7 +281,7 @@ describe('Test /api responses', () => {
 
           let { holiday } = JSON.parse(response.text)
 
-          expect(holiday.date.slice(0, 4)).toEqual(new Date().getUTCFullYear().toString())
+          expect(holiday.date.slice(0, 4)).toEqual(new Date(Date.now()).getUTCFullYear().toString())
         })
       })
     })

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -64,7 +64,7 @@ router.use(function(err, req, res, next) {
     error: {
       status: res.statusCode,
       message: err.message,
-      timestamp: new Date().toISOString(),
+      timestamp: new Date(Date.now()).toISOString(),
     },
   })
 })

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -3,7 +3,7 @@ const router = express.Router()
 const db = require('sqlite')
 const createError = require('http-errors')
 const renderPage = require('../pages/_document.js')
-const { dbmw, checkProvinceIdErr, nextHoliday } = require('../utils')
+const { dbmw, checkProvinceIdErr, nextHoliday, getCurrentHolidayYear } = require('../utils')
 const { getProvinces, getHolidaysWithProvinces, getProvincesWithHolidays } = require('../queries')
 const { displayDate } = require('../dates')
 
@@ -15,12 +15,12 @@ router.get('/', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 
   const meta = `Canada’s next stat holiday is ${getMeta(
     nextHol,
-  )}. See all statutory holidays in Canada in 2019.`
+  )}. See all statutory holidays in Canada in ${getCurrentHolidayYear()}.`
 
   return res.send(
     renderPage({
       pageComponent: 'Province',
-      title: 'Canadian statutory holidays in 2019',
+      title: `Canadian statutory holidays in ${getCurrentHolidayYear()}`,
       docProps: { meta, path: req.path },
       props: { data: { holidays, nextHoliday: nextHol } },
     }),
@@ -32,7 +32,7 @@ router.get(
   dbmw(db, getProvincesWithHolidays),
   checkProvinceIdErr,
   (req, res) => {
-    const year = new Date(Date.now()).getUTCFullYear()
+    const year = getCurrentHolidayYear()
     const { holidays, nextHoliday, nameEn: provinceName, id: provinceId } = res.locals.rows[0]
 
     const meta = `${provinceId}’s next stat holiday is ${getMeta(
@@ -58,12 +58,12 @@ router.get('/federal', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 
   const meta = `Canada’s next federal stat holiday is ${getMeta(
     nextHol,
-  )}. See all federal statutory holidays in Canada in 2019.`
+  )}. See all federal statutory holidays in Canada in ${getCurrentHolidayYear()}.`
 
   return res.send(
     renderPage({
       pageComponent: 'Province',
-      title: 'Federal statutory holidays in Canada in 2019',
+      title: `Federal statutory holidays in Canada in ${getCurrentHolidayYear()}`,
       docProps: { meta, path: req.path },
       props: { data: { holidays, nextHoliday: nextHol, federal: true } },
     }),
@@ -76,8 +76,7 @@ router.get('/provinces', dbmw(db, getProvinces), (req, res) => {
       pageComponent: 'Provinces',
       title: 'All regions in Canada — Canada statutory holidays',
       docProps: {
-        meta:
-          'Upcoming stat holidays for all regions in Canada. See all federal statutory holidays in Canada in 2019.',
+        meta: `Upcoming stat holidays for all regions in Canada. See all federal statutory holidays in Canada in ${getCurrentHolidayYear()}.`,
         path: req.path,
       },
       props: { data: { provinces: res.locals.rows } },

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -32,7 +32,7 @@ router.get(
   dbmw(db, getProvincesWithHolidays),
   checkProvinceIdErr,
   (req, res) => {
-    const year = new Date().getUTCFullYear()
+    const year = new Date(Date.now()).getUTCFullYear()
     const { holidays, nextHoliday, nameEn: provinceName, id: provinceId } = res.locals.rows[0]
 
     const meta = `${provinceId}’s next stat holiday is ${getMeta(

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -1,4 +1,4 @@
-const { array2Obj, nextHoliday, upcomingHolidays } = require('../index')
+const { array2Obj, nextHoliday, upcomingHolidays, getCurrentHolidayYear } = require('../index')
 const holidays = require('./data.skip')
 
 describe('Test array2Obj', () => {
@@ -74,5 +74,42 @@ describe('Test upcomingHolidays', () => {
   test('returns no holidays for April 1st', () => {
     const dateString = '2019-04-01'
     expect(upcomingHolidays(holidays, dateString).length).toEqual(0)
+  })
+})
+
+describe('Test getCurrentHolidayYear', () => {
+  const RealDate = Date
+
+  afterEach(() => {
+    global.Date = RealDate
+  })
+
+  const mockDate = dateString => {
+    global.Date.now = () => new Date(dateString)
+  }
+
+  test('returns the current year for 2019', () => {
+    mockDate('2019-01-01')
+    expect(getCurrentHolidayYear()).toEqual(2019)
+  })
+
+  test('returns the current year for 2020', () => {
+    mockDate('2020-01-01')
+    expect(getCurrentHolidayYear()).toEqual(2020)
+  })
+
+  test('returns 2019 for December 25th, 2019', () => {
+    mockDate('2019-12-25')
+    expect(getCurrentHolidayYear()).toEqual(2019)
+  })
+
+  test('returns 2020 for December 26th, 2019', () => {
+    mockDate('2019-12-26')
+    expect(getCurrentHolidayYear()).toEqual(2020)
+  })
+
+  test('returns 2020 for December 31st, 2019', () => {
+    mockDate('2019-12-31')
+    expect(getCurrentHolidayYear()).toEqual(2020)
   })
 })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -28,7 +28,7 @@ const dbmw = (db, cb) => {
       const year = parseInt(req.query.year)
 
       if (![2019, 2020, 2021].includes(year)) {
-        return new Date(Date.now()).getUTCFullYear()
+        return getCurrentHolidayYear()
       }
 
       return year

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -141,6 +141,20 @@ const upcomingHolidays = (holidays, dateString) => {
   return holidays.filter(holiday => holiday.date >= dateString)
 }
 
+/**
+ * This function returns the current year, except after December 26th it returns the next year
+ */
+const getCurrentHolidayYear = () => {
+  const d = new Date(Date.now())
+
+  // return the next year if Dec 26 or later
+  if (d.getUTCMonth() === 11 && d.getUTCDate() >= 26) {
+    return d.getUTCFullYear() + 1
+  }
+
+  return d.getUTCFullYear()
+}
+
 module.exports = {
   html,
   metaIfSHA,
@@ -150,4 +164,5 @@ module.exports = {
   checkProvinceIdErr,
   nextHoliday,
   upcomingHolidays,
+  getCurrentHolidayYear,
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -28,7 +28,7 @@ const dbmw = (db, cb) => {
       const year = parseInt(req.query.year)
 
       if (![2019, 2020, 2021].includes(year)) {
-        return new Date().getUTCFullYear()
+        return new Date(Date.now()).getUTCFullYear()
       }
 
       return year
@@ -107,7 +107,7 @@ const array2Obj = (arr, key = 'id') => {
  */
 const nextHoliday = (holidays, dateString) => {
   if (!dateString) {
-    dateString = new Date().toISOString().substring(0, 10)
+    dateString = new Date(Date.now()).toISOString().substring(0, 10)
   }
 
   const nextDate = holidays.find(holiday => {
@@ -135,7 +135,7 @@ const nextHoliday = (holidays, dateString) => {
  */
 const upcomingHolidays = (holidays, dateString) => {
   if (!dateString) {
-    dateString = new Date().toISOString().substring(0, 10)
+    dateString = new Date(Date.now()).toISOString().substring(0, 10)
   }
 
   return holidays.filter(holiday => holiday.date >= dateString)


### PR DESCRIPTION
hardcoding for 2019 was only going to work for 2019, so we need a better way to do 2020.