### PR TITLE
Update table styles

### DIFF
--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -41,10 +41,11 @@ const styles = ({ accent = theme.color.red } = {}) => css`
     }
 
     .h1--name {
-      font-size: 0.9em;
+      font-size: 0.75em;
       font-weight: 400;
 
       @media (${theme.mq.lg}) {
+        font-size: 0.83em;
         font-weight: 300;
       }
     }

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -39,6 +39,14 @@ const summaryRow = css`
   }
 
   @media (${theme.mq.lg}) {
+    &:first-of-type {
+      .key,
+      .value,
+      .value2 {
+        border-top: none;
+      }
+    }
+
     .key,
     .value,
     .value2 {
@@ -46,11 +54,15 @@ const summaryRow = css`
       padding-right: ${theme.space.lg};
       padding-top: ${theme.space.md};
       padding-bottom: ${theme.space.md};
-      border-bottom: 2px solid ${theme.color.greyLight};
+      border-top: 2px solid ${theme.color.greyLight};
 
       a {
         color: ${theme.color.red};
       }
+    }
+
+    &.repeatDate .key {
+      visibility: hidden;
     }
 
     .key {

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -3,8 +3,8 @@ const { css } = require('emotion')
 const { theme } = require('../styles')
 
 const summaryRow = css`
-  margin-bottom: ${theme.space.sm};
-  border-bottom: 1px solid ${theme.color.greyLight};
+  margin-bottom: ${theme.space.md};
+  border-bottom: 2px solid ${theme.color.greyLight};
 
   @media (${theme.mq.lg}) {
     display: table-row;
@@ -21,17 +21,21 @@ const summaryRow = css`
 
   .key {
     font-weight: 700;
-    margin-bottom: ${theme.space.xxs};
+    margin-bottom: ${theme.space.xs};
   }
 
   .value {
     white-space: pre-wrap;
-    margin-bottom: ${theme.space.sm};
+    margin-bottom: ${theme.space.xxs};
   }
 
   .value2 {
     margin: 0;
-    margin-bottom: ${theme.space.sm};
+    margin-bottom: ${theme.space.md};
+
+    a {
+      color: inherit;
+    }
   }
 
   @media (${theme.mq.lg}) {
@@ -40,17 +44,21 @@ const summaryRow = css`
     .value2 {
       display: table-cell;
       padding-right: ${theme.space.lg};
-      padding-top: ${theme.space.xs};
-      padding-bottom: ${theme.space.xs};
-      border-bottom: 1px solid ${theme.color.greyLight};
+      padding-top: ${theme.space.md};
+      padding-bottom: ${theme.space.md};
+      border-bottom: 2px solid ${theme.color.greyLight};
+
+      a {
+        color: ${theme.color.red};
+      }
     }
 
     .key {
-      width: 55%;
+      width: 60%;
     }
 
     .value {
-      width: 45%;
+      width: 25%;
     }
   }
 `
@@ -58,11 +66,11 @@ const summaryRow = css`
 const summaryRow2 = css`
   @media (${theme.mq.lg}) {
     .key {
-      width: 40%;
+      width: 55%;
     }
 
     .value {
-      width: 40%;
+      width: 25%;
     }
 
     .value2 {

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -1,10 +1,28 @@
 const { html } = require('../utils')
 const { css } = require('emotion')
-const { theme } = require('../styles')
+const { theme, visuallyHidden } = require('../styles')
 
 const summaryRow = css`
-  margin-bottom: ${theme.space.md};
-  border-bottom: 2px solid ${theme.color.greyLight};
+  padding-top: ${theme.space.md};
+  border-top: 2px solid ${theme.color.greyLight};
+
+  &:first-of-type {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  &.repeatDate {
+    border-top: none;
+    padding-top: ${theme.space.xs};
+
+    .key {
+      ${visuallyHidden};
+    }
+
+    @media (${theme.mq.md}) {
+      padding-top: ${theme.space.md};
+    }
+  }
 
   @media (${theme.mq.lg}) {
     display: table-row;
@@ -26,19 +44,14 @@ const summaryRow = css`
 
   .value {
     white-space: pre-wrap;
-    margin-bottom: ${theme.space.xxs};
-  }
-
-  .value2 {
-    margin: 0;
     margin-bottom: ${theme.space.md};
-
-    a {
-      color: inherit;
-    }
   }
 
   @media (${theme.mq.lg}) {
+    &.repeatDate .key {
+      visibility: hidden;
+    }
+
     &:first-of-type {
       .key,
       .value,
@@ -61,21 +74,30 @@ const summaryRow = css`
       }
     }
 
-    &.repeatDate .key {
-      visibility: hidden;
-    }
-
     .key {
-      width: 60%;
+      width: 70%;
     }
 
     .value {
-      width: 25%;
+      width: 30%;
     }
   }
 `
 
 const summaryRow2 = css`
+  .value {
+    margin-bottom: ${theme.space.xxs};
+  }
+
+  .value2 {
+    margin: 0;
+    margin-bottom: ${theme.space.md};
+
+    a {
+      color: inherit;
+    }
+  }
+
   @media (${theme.mq.lg}) {
     .key {
       width: 55%;

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -87,6 +87,7 @@ const createRows = (holidays, federal) => {
   }
 
   const today = new Date(Date.now()).toISOString().slice(0, 10)
+  var previousDate = null
 
   return holidays.map(holiday => {
     const row = {
@@ -102,6 +103,11 @@ const createRows = (holidays, federal) => {
 
     row.className = holiday.date < today ? 'past' : 'upcoming'
 
+    if (previousDate === holiday.date) {
+      row.className += ' repeatDate'
+    }
+
+    previousDate = holiday.date
     return row
   })
 }

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -51,8 +51,10 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     color: ${accent};
   }
 
-  div.upcoming ~ div.upcoming .key {
-    color: #585858;
+  @media (${theme.mq.lg}) {
+    div.upcoming ~ div.upcoming .key {
+      color: ${theme.color.grey};
+    }
   }
 
   #toggle-past {

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -52,7 +52,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   }
 
   div.upcoming ~ div.upcoming .key {
-    color: black;
+    color: #585858;
   }
 
   #toggle-past {
@@ -153,13 +153,13 @@ const Province = ({
                     data-label="toggle-past"
                     >Show past holidays<//
                   >
+                  <script src="/js/province.js"></script>
                 `}
             <//>
             <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>
           </div>
         </section>
       </div>
-      <script src="/js/province.js"></script>
     <//>
   `
 

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -46,6 +46,7 @@ const document = ({ title, content, docProps: { meta, path } }) => {
             word-break: break-word;
             line-height: 1.33;
             font-weight: 400;
+            color: #585858;
           }
 
           @media (${theme.mq.md}) {

--- a/src/styles.js
+++ b/src/styles.js
@@ -7,6 +7,7 @@ const theme = {
     red: '#AD1D00',
     yellowPale: '#FFFCF0',
     greyLight: '#BFC1C3',
+    grey: '#585858',
     focus: 'cornflowerblue',
     federal: { accent: '#B04F72', focus: 'cornflowerblue' },
     AB: { accent: '#a50069', focus: '#00aad2' },

--- a/src/styles.js
+++ b/src/styles.js
@@ -4,12 +4,12 @@ const { css } = require('emotion')
 
 const theme = {
   color: {
-    red: '#AD1D00',
-    yellowPale: '#FFFCF0',
-    greyLight: '#BFC1C3',
+    red: '#9f2f10',
+    yellowPale: '#fffcf0',
+    greyLight: '#bfc1c3',
     grey: '#585858',
     focus: 'cornflowerblue',
-    federal: { accent: '#B04F72', focus: 'cornflowerblue' },
+    federal: { accent: '#b04f72', focus: 'cornflowerblue' },
     AB: { accent: '#a50069', focus: '#00aad2' },
     BC: { accent: '#5475a7', focus: '#ffbf47' },
     MB: { accent: '#057d3e', focus: '#2c3135' },
@@ -18,11 +18,11 @@ const theme = {
     NS: { accent: '#006cb7', focus: '#f8d44c' },
     NT: { accent: '#0f599a', focus: '#c75997' },
     NU: { accent: '#5c5600', focus: '#5a9699' },
-    ON: { accent: '#006B3F', focus: '#333333' },
-    PE: { accent: '#008570', focus: '#99CC99' },
+    ON: { accent: '#006b3f', focus: '#333333' },
+    PE: { accent: '#008570', focus: '#99cc99' },
     QC: { accent: '#095797', focus: '#ffbf47' },
     SK: { accent: '#046a38', focus: '#fbdd40' },
-    YT: { accent: '#244C5A', focus: '#F2A900' },
+    YT: { accent: '#244c5a', focus: '#f2a900' },
   },
   space: {
     xxs: '5px',


### PR DESCRIPTION
As proposed by Tyler Benning, I've grouped the repeated dates a bit better, both on desktop and mobile.

I made the red duller, due to popular demand.
I've also made the text lighter, although I'm not sure how I feel about it.

## Screenshots

### duller red and smaller holiday name text

| before | after |
|--------|-------|
| <img width="1491" alt="Screen Shot 2019-12-26 at 10 07 30 PM" src="https://user-images.githubusercontent.com/2454380/71498959-87308f00-282c-11ea-8892-2c04142a7e04.png">     | <img width="1491" alt="Screen Shot 2019-12-26 at 10 07 27 PM" src="https://user-images.githubusercontent.com/2454380/71498960-87308f00-282c-11ea-98cd-f730a29b9f62.png">     |

### on desktop, group together repeat dates

| before | after |
|--------|-------|
| <img width="1491" alt="Screen Shot 2019-12-26 at 10 08 10 PM" src="https://user-images.githubusercontent.com/2454380/71498957-87308f00-282c-11ea-9fc0-20804984c802.png">    | <img width="1491" alt="Screen Shot 2019-12-26 at 10 08 07 PM" src="https://user-images.githubusercontent.com/2454380/71498958-87308f00-282c-11ea-9ea5-dff5490c1f79.png">   |

### on mobile, group together repeat dates

| before | after |
|--------|-------|
| <img width="555" alt="Screen Shot 2019-12-26 at 10 08 39 PM" src="https://user-images.githubusercontent.com/2454380/71498955-87308f00-282c-11ea-978b-9c5a740eba06.png">     | <img width="555" alt="Screen Shot 2019-12-26 at 10 08 37 PM" src="https://user-images.githubusercontent.com/2454380/71498956-87308f00-282c-11ea-82e9-93cab43891bc.png">     |
