### PR TITLE
Hide button unless there are 6 past holidays

### DIFF
--- a/public/js/province.js
+++ b/public/js/province.js
@@ -1,48 +1,4 @@
 /* eslint-disable */
-function throttle(callback, limit) {
-  var wait = false;
-  /* Initially, we're not waiting */
-
-  return function () {
-    /* We return a throttled function */
-    if (!wait) {
-      /* If we're not waiting */
-      callback.call();
-      /* Execute user's function */
-
-      wait = true;
-      /* Prevent future invocations */
-
-      setTimeout(function () {
-        /* After a period of time */
-        wait = false;
-        /* And allow future invocations */
-      }, limit);
-    }
-  };
-}
-
-function updateCSSVar() {
-  /* First we get the viewport height and we multiple it by 1% to get a value for a vh unit */
-  var vh = window.innerHeight * 0.01;
-  /* Then we set the value in the --vh custom property to the root of the document */
-
-  document.documentElement.style.setProperty('--vh', vh + 'px');
-}
-
-function ifLandscapeMode(cb) {
-  return function () {
-    /* you're in LANDSCAPE mode */
-    if (window.matchMedia('(orientation: landscape)').matches) {
-      cb();
-    }
-  };
-}
-/* We listen to the resize event every 5 milliseconds */
-
-
-window.addEventListener('resize', throttle(ifLandscapeMode(updateCSSVar), 5));
-updateCSSVar();
 var pastEvents = document.querySelectorAll('.past');
 var allEvents = document.getElementsByTagName('dt');
 var rows = document.querySelectorAll('.row');

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -113,8 +113,14 @@ const createRows = (holidays, federal) => {
 }
 
 const ifPastHolidays = (holidays = []) => {
+  // there must be at least 6 past holidays before the button appears
+  const minimum = 6
   const today = new Date(Date.now()).toISOString().slice(0, 10)
-  return holidays[0].date < today
+  if (!holidays[minimum]) {
+    return false
+  }
+
+  return holidays[minimum].date < today
 }
 
 const Province = ({
@@ -161,12 +167,15 @@ const Province = ({
                     data-label="toggle-past"
                     >Show past holidays<//
                   >
-                  <script src="/js/province.js"></script>
                 `}
             <//>
             <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>
           </div>
         </section>
+        ${ifPastHolidays(holidays) &&
+          html`
+            <script src="/js/province.js"></script>
+          `}
       </div>
     <//>
   `


### PR DESCRIPTION
Showing the button right away seems overly eager. Keeping New Year's Day up there seems fine actually.

Also:

- moved the `province.js` include to the bottom of Province so that it works properly (oops) 
- removed the code that updates the now-deprecated `--vh` variable