### PR TITLE
printing looks better now

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
 # TODO
 
 - add a better province picker
-- add a print feature
 - add an export ics feature
 - sticky header?
+- add a print button?
 - add holidays by year to the frontend
   - 2021
   - 2022
@@ -13,6 +13,7 @@
 
 # DONE
 
+- add print styles
 - skip link
 - quick feedback page
 - continuous deployment

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -2,6 +2,7 @@ const { renderStylesToString } = require('emotion-server')
 const render = require('preact-render-to-string')
 const { html, metaIfSHA, gaIfProd } = require('../utils')
 const { theme } = require('../styles')
+const { printStyles } = require('../printStyles')
 
 const document = ({ title, content, docProps: { meta, path } }) => {
   return `
@@ -77,6 +78,8 @@ const document = ({ title, content, docProps: { meta, path } }) => {
           .pcraig3 {
             color: ${theme.color.red};
           }
+
+         ${printStyles};
         </style>
       </head>
       <body id="body">

--- a/src/printStyles.js
+++ b/src/printStyles.js
@@ -1,0 +1,55 @@
+module.exports = {
+  printStyles: `
+  @media print {
+    @page {
+      size: 297mm 420mm; /* A4 page, otherwise Chrome uses mobile styles */
+    }
+
+    body {
+      font-size: 11px;
+      line-height: 1.2;
+      font-family: sans-serif;
+      color: black;
+    }
+
+    header,
+    section:first-of-type,
+    .bottom-link {
+      display: none;
+    }
+
+    main section {
+      padding: 0 !important;
+    }
+
+    header nav,
+    main section > div {
+      width: 100% !important;
+    }
+
+    section h2:first-of-type {
+      padding-top: 0 !important;
+      padding-bottom: 24px !important;
+    }
+
+    dl {
+      margin-bottom: 0 !important;
+    }
+
+    dt.key,
+    dd.value,
+    dd.value2 {
+      width: 33% !important;
+      padding: 8px 8px 8px 0 !important;
+      border-width: 1px !important;
+    }
+    dt.key {
+      width: 45% !important;
+    }
+    dd.value,
+    dd.value2 {
+      width: 27.5% !important;
+    }
+  }
+`,
+}


### PR DESCRIPTION
browsers are weird, but by and large we have an improvement.

## print preview (in safari)

Safari is where we have the biggest improvement, so let's show that one.

This is taken from the print preview little PDF it shows you when you ask to print the page.

| before | after |
|--------|-------|
| <img width="246" alt="Screen Shot 2020-01-03 at 12 57 48 AM" src="https://user-images.githubusercontent.com/2454380/71709292-38529e80-2dc4-11ea-8291-c5ad7daada94.png">     |  <img width="246" alt="Screen Shot 2020-01-03 at 12 57 28 AM" src="https://user-images.githubusercontent.com/2454380/71709293-38529e80-2dc4-11ea-88c2-4e40f4e331ee.png">    |

