### PR TITLE
"Add to calendar" button to the homepage and provinces pages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 - add a better province picker
-- add an export ics feature
 - sticky header?
 - add a print button?
 - add holidays by year to the frontend
@@ -13,6 +12,7 @@
 
 # DONE
 
+- add an export ics feature
 - bug: federal hols are not shown on the homepage holidays table
 - add print styles
 - skip link

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,40 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -3816,6 +3850,17 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ics": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/ics/-/ics-2.18.0.tgz",
+      "integrity": "sha512-QEhHNWk8Bh/ukjnhXIDGoaphnPA6yiCUiym6k9slqv60SBfMVM7uM2jzLOpqQzgq+YArde3Qyf0+fz7XxLmPDQ==",
+      "requires": {
+        "@hapi/joi": "^15.1.1",
+        "lodash": "^4.17.15",
+        "moment": "^2.24.0",
+        "uuid": "^3.3.3"
+      }
+    },
     "ienoopen": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
@@ -5384,6 +5429,11 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "morgan": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "helmet": "^3.21.2",
     "htm": "^2.2.1",
     "http-errors": "^1.7.3",
+    "ics": "^2.18.0",
     "morgan": "^1.9.1",
     "preact": "^10.1.1",
     "preact-render-to-string": "^5.1.3",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,11 +1,12 @@
 const { html } = require('../utils')
 const { css } = require('emotion')
 const { theme } = require('../styles')
-const { Expand, Collapse } = require('./ExpandCollapse')
+const { Expand, Collapse, Download } = require('./Svg')
 
 const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) => css`
   margin: 0;
   width: auto;
+  display: inline-block;
   overflow: visible;
   background: transparent;
   font: inherit;
@@ -14,6 +15,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   -moz-osx-font-smoothing: inherit;
   -webkit-appearance: none;
   border-radius: 1px;
+  text-decoration: none;
 
   border: 2px solid ${accent};
   border-bottom: none;
@@ -25,14 +27,14 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
 
   &:hover,
   &:focus {
-    color: white;
+    color: white !important;
     background-color: ${accent};
     box-shadow: 0 4px black;
   }
 
   &:focus {
-    outline: 3px dashed ${focus};
-    outline-offset: 8px;
+    outline: 3px dashed ${focus} !important;
+    outline-offset: 8px !important;
   }
 
   &::-moz-focus-inner {
@@ -83,12 +85,28 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   }
 `
 
-const Button = ({ children, color = {}, ...props }) => {
+const NativeButton = ({ children, color = {}, ...props }) => {
   return html`
-    <button class=${styles(color)} ...${props}>
-      <${Expand} //><${Collapse} //><span>${children}</span>
-    </button>
+    <button class=${styles(color)} ...${props}>${children}</button>
   `
+}
+
+const LinkButton = ({ children, color = {}, ...props }) => {
+  return html`
+    <a class=${styles(color)} role="button" draggable="false" ...${props}>${children}</a>
+  `
+}
+
+const Button = ({ children, color = {}, ...props }) => {
+  return props.href
+    ? html`
+        <${LinkButton} color=${color} ...${props}><${Download} //><span>${children}</span><//>
+      `
+    : html`
+        <${NativeButton} color=${color} ...${props}
+          ><${Expand} //><${Collapse} //><span>${children}</span><//
+        >
+      `
 }
 
 module.exports = Button

--- a/src/components/Svg.js
+++ b/src/components/Svg.js
@@ -80,4 +80,25 @@ const Collapse = () => {
   `
 }
 
-module.exports = { Expand, Collapse }
+const Download = () => {
+  return html`
+    <svg
+      x="0px"
+      y="0px"
+      viewBox="0 0 451.111 451.111"
+      xml:space="preserve"
+      fill="#DD2E44"
+      style="vertical-align: -0.125em;-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);"
+      class="arrows--collapse"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="m225.556 354.445 145-145-48.333-48.333-64.444 64.444v-225.556h-64.444v225.556l-64.444-64.444-48.333 48.333z"
+      />
+      <path d="m0 386.667h451.111v64.444h-451.111z" />
+    </svg>
+  `
+}
+
+module.exports = { Expand, Collapse, Download }

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -4,7 +4,7 @@ const { html } = require('../../utils')
 
 const Button = require('../Button.js')
 
-test('Button displays properly', () => {
+test('Button displays properly as a button', () => {
   expect(1).toBe(1)
   const $ = cheerio.load(
     render(
@@ -18,4 +18,21 @@ test('Button displays properly', () => {
   expect($('button').attr('id')).toEqual('click-button')
   expect($('button').attr('type')).toEqual('click')
   expect($('button').text()).toEqual('Click me')
+})
+
+test('Button displays properly as a link', () => {
+  expect(1).toBe(1)
+  const $ = cheerio.load(
+    render(
+      html`
+        <${Button} id="link-button" href="/download">Click me</button>
+      `,
+    ),
+  )
+
+  expect($('button').length).toBe(0)
+  expect($('a').length).toBe(1)
+  expect($('a').attr('id')).toEqual('link-button')
+  expect($('a').attr('href')).toEqual('/download')
+  expect($('a').text()).toEqual('Click me')
 })

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -189,13 +189,14 @@ const Province = ({
                   <span class=${visuallyHidden}> statutory</span> holidays in ${year}
                 </h2>
                 <${Button}
-                  id="ics"
-                  href="#file"
+                  id="download-holidays"
+                  href="/canada-holidays-2020.ics"
+                  download="canada-holidays-2020.ics"
                   color=${federal || provinceId
                     ? theme.color[federal ? 'federal' : provinceId]
                     : {}}
                   data-event="true"
-                  data-label="download"
+                  data-label="download-holidays"
                   >Add to your calendar<//
                 >
               </div>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -49,13 +49,6 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
       color: ${theme.color.grey};
     }
   }
-
-  #toggle-past {
-    margin-top: ${theme.space.sm};
-    margin-bottom: ${theme.space.xl};
-  }
-
-  >
 `
 
 const titleStyles = css`
@@ -189,9 +182,12 @@ const Province = ({
                   <span class=${visuallyHidden}> statutory</span> holidays in ${year}
                 </h2>
                 <${Button}
-                  id="download-holidays"
-                  href="/canada-holidays-2020.ics"
-                  download="canada-holidays-2020.ics"
+                  href=${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}
+                  download=${federal
+                    ? `canada-holidays-federal-${year}.ics`
+                    : provinceId
+                    ? `canada-holidays-${provinceId}-${year}.ics`
+                    : `canada-holidays-${year}.ics`}
                   color=${federal || provinceId
                     ? theme.color[federal ? 'federal' : provinceId]
                     : {}}

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -30,13 +30,6 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     }
   }
 
-  h2 {
-    margin: 0;
-    padding-top: ${theme.space.md};
-    padding-bottom: ${theme.space.xl};
-    font-size: 1.566em;
-  }
-
   div.past {
     > * {
       opacity: 0.6;
@@ -60,6 +53,36 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   #toggle-past {
     margin-top: ${theme.space.sm};
     margin-bottom: ${theme.space.xl};
+  }
+
+  >
+`
+
+const titleStyles = css`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-direction: column;
+  margin-top: ${theme.space.md};
+  margin-bottom: ${theme.space.md};
+
+  @media (${theme.mq.lg}) {
+    flex-direction: row;
+  }
+
+  h2 {
+    margin: 0;
+    margin-bottom: 10px;
+    font-size: 1.566em;
+  }
+
+  button,
+  a[role='button'] {
+    margin-bottom: ${theme.space.md};
+
+    @media (${theme.mq.md}) {
+      margin-bottom: ${theme.space.lg};
+    }
   }
 `
 
@@ -160,23 +183,22 @@ const Province = ({
               title=${getTitleString(provinceName, federal, year)}
               rows=${createRows(holidays, federal)}
             >
-              <h2 id="holidays-table">
-                ${provinceName}${federal ? ' federal' : ''}
-                <span class=${visuallyHidden}> statutory</span> holidays in ${year}
-              </h2>
-              ${ifPastHolidays(holidays) &&
-                html`
-                  <${Button}
-                    id="toggle-past"
-                    color=${federal || provinceId
-                      ? theme.color[federal ? 'federal' : provinceId]
-                      : {}}
-                    style="display: none;"
-                    data-event="true"
-                    data-label="toggle-past"
-                    >Show past holidays<//
-                  >
-                `}
+              <div class=${titleStyles}>
+                <h2 id="holidays-table">
+                  ${provinceName}${federal ? ' federal' : ''}
+                  <span class=${visuallyHidden}> statutory</span> holidays in ${year}
+                </h2>
+                <${Button}
+                  id="ics"
+                  href="#file"
+                  color=${federal || provinceId
+                    ? theme.color[federal ? 'federal' : provinceId]
+                    : {}}
+                  data-event="true"
+                  data-label="download"
+                  >Add to your calendar<//
+                >
+              </div>
             <//>
             <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>
           </div>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -69,12 +69,29 @@ const titleStyles = css`
     font-size: 1.566em;
   }
 
+  h2 + div {
+    margin-bottom: ${theme.space.md};
+  }
+
   button,
   a[role='button'] {
-    margin-bottom: ${theme.space.md};
+    text-align: left;
+  }
 
-    @media (${theme.mq.md}) {
+  @media (${theme.mq.md}) {
+    h2 {
+      flex: 3;
+    }
+
+    h2 + div {
+      flex: 2;
+      text-align: right;
       margin-bottom: ${theme.space.lg};
+    }
+
+    button,
+    a[role='button'] {
+      min-width: 234px;
     }
   }
 `
@@ -181,20 +198,22 @@ const Province = ({
                   ${provinceName}${federal ? ' federal' : ''}
                   <span class=${visuallyHidden}> statutory</span> holidays in ${year}
                 </h2>
-                <${Button}
-                  href=${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}
-                  download=${federal
-                    ? `canada-holidays-federal-${year}.ics`
-                    : provinceId
-                    ? `canada-holidays-${provinceId}-${year}.ics`
-                    : `canada-holidays-${year}.ics`}
-                  color=${federal || provinceId
-                    ? theme.color[federal ? 'federal' : provinceId]
-                    : {}}
-                  data-event="true"
-                  data-label="download-holidays"
-                  >Add to your calendar<//
-                >
+                <div>
+                  <${Button}
+                    href=${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}
+                    download=${federal
+                      ? `canada-holidays-federal-${year}.ics`
+                      : provinceId
+                      ? `canada-holidays-${provinceId}-${year}.ics`
+                      : `canada-holidays-${year}.ics`}
+                    color=${federal || provinceId
+                      ? theme.color[federal ? 'federal' : provinceId]
+                      : {}}
+                    data-event="true"
+                    data-label="download-holidays"
+                    >Add to your calendar<//
+                  >
+                </div>
               </div>
             <//>
             <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -24,4 +24,18 @@ describe('Test ui responses', () => {
       expect(response.statusCode).toBe(200)
     })
   })
+
+  describe('Test /ics/federal response', () => {
+    test('it should return 200', async () => {
+      const response = await request(app).get('/ics/federal')
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('Test /ics/AB response', () => {
+    test('it should return 200', async () => {
+      const response = await request(app).get('/ics/AB')
+      expect(response.statusCode).toBe(200)
+    })
+  })
 })

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -1,0 +1,27 @@
+const request = require('supertest')
+const db = require('sqlite')
+const Promise = require('bluebird')
+const app = require('../../server.js')
+
+describe('Test ui responses', () => {
+  beforeAll(async () => {
+    await Promise.resolve()
+      // First, try to open the database
+      .then(() => db.open('./database.sqlite', { Promise, cached: true })) // <=
+      // Update db schema to the latest version using SQL-based migrations
+      .then(() => db.migrate()) // <=
+      // Display error message if something went wrong
+      .catch(err => console.error(err.stack)) // eslint-disable-line no-console
+  })
+
+  afterAll(() => {
+    db.close()
+  })
+
+  describe('Test /ics response', () => {
+    test('it should return 200', async () => {
+      const response = await request(app).get('/ics')
+      expect(response.statusCode).toBe(200)
+    })
+  })
+})

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -3,7 +3,7 @@ const db = require('sqlite')
 const Promise = require('bluebird')
 const app = require('../../server.js')
 
-describe('Test ui responses', () => {
+describe('Test ics responses', () => {
   beforeAll(async () => {
     await Promise.resolve()
       // First, try to open the database
@@ -36,6 +36,14 @@ describe('Test ui responses', () => {
     test('it should return 200', async () => {
       const response = await request(app).get('/ics/AB')
       expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('Test /ics/fake response', () => {
+    test('it should return 302', async () => {
+      const response = await request(app).get('/ics/fake')
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe('/province/fake')
     })
   })
 })

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -3,35 +3,9 @@ const router = express.Router()
 const db = require('sqlite')
 const ics = require('ics')
 const createError = require('http-errors')
-const addDays = require('date-fns/addDays')
-const { dbmw } = require('../utils')
+const { dbmw } = require('../utils/index')
+const { startDate, endDate, getDescription } = require('../utils/ics')
 const { getHolidaysWithProvinces } = require('../queries')
-
-/**
- * Takes an ISO-formatted date string (1990-10-08), and returns an array with [year, month, day]
- * @param {string} dateString an ISO-formatted date string (1990-10-08)
- */
-const startDate = dateString => dateString.split('-')
-
-/**
- * Takes an ISO-formatted date string (1990-10-08), and returns an array with the [year, month, day] of the NEXT day
- * @param {*} dateString an ISO-formatted date string (1990-10-08)
- */
-const endDate = dateString =>
-  addDays(new Date(dateString), 1)
-    .toISOString()
-    .substring(0, 10)
-    .split('-')
-
-/**
- * Returns a description string for .ics files
- * If a national holiday, returns "National holiday" else a warning that the holiday isn't observed everywhere
- * @param {obj} holiday a holiday object containing a 'provinces' key
- */
-const getDescription = holiday =>
-  holiday.provinces.length === 13
-    ? 'National holiday'
-    : 'This is not a national holiday; it may not be observed in your region'
 
 /**
  * Returns an event formatted in a way the ICS library understands
@@ -50,7 +24,6 @@ const formatEvent = holiday => {
 
 /*
  titles say which provinces observe
- write a test
  make the date thing a method
 */
 router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
@@ -58,7 +31,7 @@ router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 
   ics.createEvent(formatEvent(holiday), (error, value) => {
     if (error) {
-      throw new createError(500, 'Error: creating events for route: /ics')
+      throw new createError(500, `Error: creating events for route: ${req.path}`)
     }
 
     res.set({
@@ -70,11 +43,12 @@ router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 })
 
 router.get('/ics/test', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const holiday = res.locals.rows[1]
+  const hols = [res.locals.rows[0], res.locals.rows[1]]
+  const formattedEvents = hols.map(h => formatEvent(h))
 
-  ics.createEvent(formatEvent(holiday), (error, value) => {
+  ics.createEvents(formattedEvents, (error, value) => {
     if (error) {
-      throw new createError(500, 'Error: creating events for route: /ics/test')
+      throw new createError(500, `Error: creating events for route: ${req.path}`)
     }
 
     // eslint-disable-next-line no-console

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -4,7 +4,7 @@ const db = require('sqlite')
 const ics = require('ics')
 const createError = require('http-errors')
 const { dbmw } = require('../utils/index')
-const { startDate, endDate, getDescription } = require('../utils/ics')
+const { startDate, endDate, getTitle, getDescription } = require('../utils/ics')
 const { getHolidaysWithProvinces } = require('../queries')
 
 /**
@@ -15,7 +15,7 @@ const formatEvent = holiday => {
   return {
     start: startDate(holiday.date),
     end: endDate(holiday.date),
-    title: holiday.nameEn,
+    title: getTitle(holiday),
     description: getDescription(holiday),
     productId: '-//pcraig3//hols//EN',
     uid: `${new Date(holiday.date).getTime()}@hols.ca`,

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -3,58 +3,79 @@ const router = express.Router()
 const db = require('sqlite')
 const ics = require('ics')
 const createError = require('http-errors')
-const { dbmw } = require('../utils/index')
-const { startDate, endDate, getTitle, getDescription } = require('../utils/ics')
+const { dbmw, getCurrentHolidayYear } = require('../utils/index')
+const {
+  startDate,
+  endDate,
+  getTitle,
+  getNationalDescription,
+  getProvinceDescription,
+} = require('../utils/ics')
 const { getHolidaysWithProvinces } = require('../queries')
 
 /**
  * Returns an event formatted in a way the ICS library understands
  * @param {obj} holiday a holiday object
  */
-const formatEvent = holiday => {
+const formatNationalEvent = holiday => {
   return {
     start: startDate(holiday.date),
     end: endDate(holiday.date),
     title: getTitle(holiday),
-    description: getDescription(holiday),
+    description: getNationalDescription(holiday),
     productId: '-//pcraig3//hols//EN',
     uid: `${new Date(holiday.date).getTime()}@hols.ca`,
   }
 }
 
-/*
- titles say which provinces observe
- make the date thing a method
-*/
-router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const holiday = res.locals.rows[3]
+const formatProvinceEvent = holiday => {
+  return {
+    start: startDate(holiday.date),
+    end: endDate(holiday.date),
+    title: holiday.nameEn,
+    description: getProvinceDescription(holiday),
+    productId: '-//pcraig3//hols//EN',
+    uid: `${new Date(holiday.date).getTime()}@hols.ca`,
+  }
+}
 
-  ics.createEvent(formatEvent(holiday), (error, value) => {
+const downloadICS = (req, res, modifier = null) => {
+  return (error, value) => {
     if (error) {
       throw new createError(500, `Error: creating events for route: ${req.path}`)
     }
 
     res.set({
       'Content-Type': 'text/calendar',
-      'Content-disposition': 'attachment; filename=canada-holidays-2020.ics',
+      'Content-disposition': `attachment; filename=canada-holidays-${
+        modifier ? `${modifier}-` : ''
+      }${getCurrentHolidayYear()}.ics`,
     })
     return res.send(value)
-  })
+  }
+}
+
+router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+  const holidays = res.locals.rows.map(h => formatNationalEvent(h))
+
+  ics.createEvents(holidays, downloadICS(req, res))
 })
 
-router.get('/ics/test', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const formattedEvents = [res.locals.rows[1]].map(h => formatEvent(h))
+router.get('/ics/federal', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+  const filteredRows = res.locals.rows.filter(h => h.federal)
+  const holidays = filteredRows.map(h => formatProvinceEvent(h))
 
-  ics.createEvents(formattedEvents, (error, value) => {
-    if (error) {
-      throw new createError(500, `Error: creating events for route: ${req.path}`)
-    }
+  ics.createEvents(holidays, downloadICS(req, res, 'federal'))
+})
 
-    // eslint-disable-next-line no-console
-    console.log(value)
+router.get('/ics/:provinceId', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+  const provinceId = req.params.provinceId.toUpperCase()
+  const filteredRows = res.locals.rows.filter(h => {
+    return h.provinces.find(p => p.id === provinceId)
   })
+  const holidays = filteredRows.map(h => formatProvinceEvent(h))
 
-  return res.send('ok')
+  ics.createEvents(holidays, downloadICS(req, res, provinceId))
 })
 
 module.exports = router

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -27,7 +27,7 @@ const formatEvent = holiday => {
  make the date thing a method
 */
 router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const holiday = res.locals.rows[1]
+  const holiday = res.locals.rows[3]
 
   ics.createEvent(formatEvent(holiday), (error, value) => {
     if (error) {
@@ -36,15 +36,14 @@ router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 
     res.set({
       'Content-Type': 'text/calendar',
-      'Content-disposition': 'attachment; filename=newYear.ics',
+      'Content-disposition': 'attachment; filename=canada-holidays-2020.ics',
     })
     return res.send(value)
   })
 })
 
 router.get('/ics/test', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const hols = [res.locals.rows[0], res.locals.rows[1]]
-  const formattedEvents = hols.map(h => formatEvent(h))
+  const formattedEvents = [res.locals.rows[1]].map(h => formatEvent(h))
 
   ics.createEvents(formattedEvents, (error, value) => {
     if (error) {

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -1,0 +1,87 @@
+const express = require('express')
+const router = express.Router()
+const db = require('sqlite')
+const ics = require('ics')
+const createError = require('http-errors')
+const addDays = require('date-fns/addDays')
+const { dbmw } = require('../utils')
+const { getHolidaysWithProvinces } = require('../queries')
+
+/**
+ * Takes an ISO-formatted date string (1990-10-08), and returns an array with [year, month, day]
+ * @param {string} dateString an ISO-formatted date string (1990-10-08)
+ */
+const startDate = dateString => dateString.split('-')
+
+/**
+ * Takes an ISO-formatted date string (1990-10-08), and returns an array with the [year, month, day] of the NEXT day
+ * @param {*} dateString an ISO-formatted date string (1990-10-08)
+ */
+const endDate = dateString =>
+  addDays(new Date(dateString), 1)
+    .toISOString()
+    .substring(0, 10)
+    .split('-')
+
+/**
+ * Returns a description string for .ics files
+ * If a national holiday, returns "National holiday" else a warning that the holiday isn't observed everywhere
+ * @param {obj} holiday a holiday object containing a 'provinces' key
+ */
+const getDescription = holiday =>
+  holiday.provinces.length === 13
+    ? 'National holiday'
+    : 'This is not a national holiday; it may not be observed in your region'
+
+/**
+ * Returns an event formatted in a way the ICS library understands
+ * @param {obj} holiday a holiday object
+ */
+const formatEvent = holiday => {
+  return {
+    start: startDate(holiday.date),
+    end: endDate(holiday.date),
+    title: holiday.nameEn,
+    description: getDescription(holiday),
+    productId: '-//pcraig3//hols//EN',
+    uid: `${new Date(holiday.date).getTime()}@hols.ca`,
+  }
+}
+
+/*
+ titles say which provinces observe
+ write a test
+ make the date thing a method
+*/
+router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+  const holiday = res.locals.rows[1]
+
+  ics.createEvent(formatEvent(holiday), (error, value) => {
+    if (error) {
+      throw new createError(500, 'Error: creating events for route: /ics')
+    }
+
+    res.set({
+      'Content-Type': 'text/calendar',
+      'Content-disposition': 'attachment; filename=newYear.ics',
+    })
+    return res.send(value)
+  })
+})
+
+router.get('/ics/test', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+  const holiday = res.locals.rows[1]
+
+  ics.createEvent(formatEvent(holiday), (error, value) => {
+    if (error) {
+      throw new createError(500, 'Error: creating events for route: /ics/test')
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(value)
+  })
+
+  return res.send('ok')
+})
+
+module.exports = router

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -3,7 +3,7 @@ const router = express.Router()
 const db = require('sqlite')
 const ics = require('ics')
 const createError = require('http-errors')
-const { dbmw, getCurrentHolidayYear } = require('../utils/index')
+const { dbmw, isProvinceId, getCurrentHolidayYear } = require('../utils/index')
 const {
   startDate,
   endDate,
@@ -69,7 +69,12 @@ router.get('/ics/federal', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 })
 
 router.get('/ics/:provinceId', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const provinceId = req.params.provinceId.toUpperCase()
+  let provinceId = req.params.provinceId
+  if (!isProvinceId(provinceId)) {
+    return res.redirect(`/province/${provinceId}`)
+  }
+
+  provinceId = provinceId.toUpperCase()
   const filteredRows = res.locals.rows.filter(h => {
     return h.provinces.find(p => p.id === provinceId)
   })

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -30,8 +30,8 @@ router.get('/', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 
 router.get(
   '/province/:provinceId',
-  dbmw(db, getProvincesWithHolidays),
   checkProvinceIdErr,
+  dbmw(db, getProvincesWithHolidays),
   (req, res) => {
     const year = getCurrentHolidayYear()
     const { holidays, nextHoliday, nameEn: provinceName, id: provinceId } = res.locals.rows[0]

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,9 @@ app.use((req, res, next) => {
 const apiRouter = require('./routes/api')
 app.use('/api', apiRouter)
 
+const icsRouter = require('./routes/ics')
+app.use(icsRouter)
+
 const uiRouter = require('./routes/ui')
 app.use(uiRouter)
 

--- a/src/utils/__tests__/ics.test.js
+++ b/src/utils/__tests__/ics.test.js
@@ -1,0 +1,54 @@
+const { startDate, endDate, getDescription } = require('../ics')
+
+describe('Test startDate', () => {
+  test('Returns [1979, 11, 07] for 1979-11-07', () => {
+    const dateString = '1979-11-07'
+    expect(startDate(dateString)).toEqual(['1979', '11', '07'])
+  })
+})
+
+describe('Test endDate', () => {
+  test('Returns [1979, 11, 08] for 1979-11-07', () => {
+    const dateString = '1979-11-07'
+    expect(endDate(dateString)).toEqual(['1979', '11', '08'])
+  })
+
+  // test month
+  test('Returns [1979, 12, 01] for 1979-11-30', () => {
+    const dateString = '1979-11-30'
+    expect(endDate(dateString)).toEqual(['1979', '12', '01'])
+  })
+
+  // test year
+  test('Returns [1980, 01, 01] for 1979-12-31', () => {
+    const dateString = '1979-12-31'
+    expect(endDate(dateString)).toEqual(['1980', '01', '01'])
+  })
+})
+
+describe('Test getDescription', () => {
+  test('"National holiday" for a holiday with 13 provinces', () => {
+    const holidayStub = { provinces: [...Array(13).keys()] }
+    expect(getDescription(holidayStub)).toMatch('National holiday')
+  })
+
+  test('Not a national holiday for a holiday with 1 province', () => {
+    const holidayStub = { provinces: [...Array(1).keys()] }
+    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+  })
+
+  test('Not a national holiday for a holiday with 12 provinces', () => {
+    const holidayStub = { provinces: [...Array(12).keys()] }
+    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+  })
+
+  test('Not a national holiday for a holiday with 14 provinces', () => {
+    const holidayStub = { provinces: [...Array(14).keys()] }
+    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+  })
+
+  test('Not a national holiday for an obj without a "provinces" key', () => {
+    const holidayStub = {}
+    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+  })
+})

--- a/src/utils/__tests__/ics.test.js
+++ b/src/utils/__tests__/ics.test.js
@@ -1,4 +1,4 @@
-const { startDate, endDate, getDescription } = require('../ics')
+const { startDate, endDate, getDescription, getTitle } = require('../ics')
 
 describe('Test startDate', () => {
   test('Returns [1979, 11, 07] for 1979-11-07', () => {
@@ -23,6 +23,45 @@ describe('Test endDate', () => {
   test('Returns [1980, 01, 01] for 1979-12-31', () => {
     const dateString = '1979-12-31'
     expect(endDate(dateString)).toEqual(['1980', '01', '01'])
+  })
+})
+
+describe('Test getTitle', () => {
+  const name = { nameEn: 'Fun holiday' }
+  test('returns same title for a holiday with 13 provinces', () => {
+    const holidayStub = { provinces: [...Array(13).keys()], ...name }
+    expect(getTitle(holidayStub)).toMatch('Fun holiday')
+  })
+
+  // 0 provinces (should never happen)
+  test('returns same title for a holiday with 0 provinces', () => {
+    const holidayStub = { ...name }
+    expect(getTitle(holidayStub)).toMatch('Fun holiday')
+  })
+
+  // 1 province
+  test('returns title with 1 bracketed province ID for a holiday with 1 province', () => {
+    const holidayStub = { provinces: [{ id: 'AB' }], ...name }
+    expect(getTitle(holidayStub)).toMatch('Fun holiday (AB)')
+  })
+
+  // 1 province AND federal
+  test('returns title with 1 bracketed province ID for a holiday with 1 province', () => {
+    const holidayStub = { provinces: [{ id: 'AB' }], federal: 1, ...name }
+    expect(getTitle(holidayStub)).toMatch('Fun holiday (AB, Federal)')
+  })
+
+  // 12 provinces
+  test('returns title with 12 bracketed province IDs for a holiday with 12 provinces', () => {
+    // missing "AB"
+    const ids = ['BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT']
+    const provinces = ids.map(v => {
+      return { id: v }
+    })
+    const holidayStub = { provinces, ...name }
+    expect(getTitle(holidayStub)).toMatch(
+      'Fun holiday (BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT)',
+    )
   })
 })
 

--- a/src/utils/__tests__/ics.test.js
+++ b/src/utils/__tests__/ics.test.js
@@ -1,4 +1,10 @@
-const { startDate, endDate, getDescription, getTitle } = require('../ics')
+const {
+  startDate,
+  endDate,
+  getNationalDescription,
+  getProvinceDescription,
+  getTitle,
+} = require('../ics')
 
 describe('Test startDate', () => {
   test('Returns [1979, 11, 07] for 1979-11-07', () => {
@@ -65,29 +71,81 @@ describe('Test getTitle', () => {
   })
 })
 
-describe('Test getDescription', () => {
+describe('Test getNationalDescription', () => {
   test('"National holiday" for a holiday with 13 provinces', () => {
     const holidayStub = { provinces: [...Array(13).keys()] }
-    expect(getDescription(holidayStub)).toMatch('National holiday')
+    expect(getNationalDescription(holidayStub)).toMatch('National holiday')
   })
 
   test('Not a national holiday for a holiday with 1 province', () => {
     const holidayStub = { provinces: [...Array(1).keys()] }
-    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+    expect(getNationalDescription(holidayStub)).toMatch('This is not a national holiday')
   })
 
   test('Not a national holiday for a holiday with 12 provinces', () => {
     const holidayStub = { provinces: [...Array(12).keys()] }
-    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+    expect(getNationalDescription(holidayStub)).toMatch('This is not a national holiday')
   })
 
   test('Not a national holiday for a holiday with 14 provinces', () => {
     const holidayStub = { provinces: [...Array(14).keys()] }
-    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+    expect(getNationalDescription(holidayStub)).toMatch('This is not a national holiday')
   })
 
   test('Not a national holiday for an obj without a "provinces" key', () => {
     const holidayStub = {}
-    expect(getDescription(holidayStub)).toMatch('This is not a national holiday')
+    expect(getNationalDescription(holidayStub)).toMatch('This is not a national holiday')
+  })
+})
+
+describe('Test getProvinceDescription', () => {
+  test('"National holiday" for a holiday with 13 provinces', () => {
+    const holidayStub = { provinces: [...Array(13).keys()] }
+    expect(getProvinceDescription(holidayStub)).toMatch('National holiday')
+  })
+
+  test('"National holiday" for an obj without a "provinces" key', () => {
+    const holidayStub = {}
+    expect(getProvinceDescription(holidayStub)).toMatch('National holiday')
+  })
+
+  // 1 province
+  test('Description for 1 province', () => {
+    const holidayStub = { provinces: [{ id: 'AB', nameEn: 'Alberta' }] }
+    expect(getProvinceDescription(holidayStub)).toMatch('Observed by Alberta.')
+  })
+
+  // 1 federal
+  test('Description for federal holiday', () => {
+    const holidayStub = { provinces: [], federal: 1 }
+    expect(getProvinceDescription(holidayStub)).toMatch('Observed by federal industries.')
+  })
+
+  // 1 province 1 federal
+  test('Description for 1 province and federal', () => {
+    const holidayStub = { provinces: [{ id: 'AB', nameEn: 'Alberta' }], federal: 1 }
+    expect(getProvinceDescription(holidayStub)).toMatch(
+      'Observed by Alberta and federal industries.',
+    )
+  })
+
+  // 2 provinces
+  test('Description for 2 provinces', () => {
+    const holidayStub = { provinces: [{ id: 'AB' }, { id: 'BC' }] }
+    expect(getProvinceDescription(holidayStub)).toMatch('Observed by AB and BC.')
+  })
+
+  // 3 provinces
+  test('Description for 3 provinces', () => {
+    const holidayStub = { provinces: [{ id: 'AB' }, { id: 'BC' }, { id: 'MB' }] }
+    expect(getProvinceDescription(holidayStub)).toMatch('Observed by AB, BC, and MB.')
+  })
+
+  // 3 provinces 1 federal
+  test('Description for 3 provinces and federal', () => {
+    const holidayStub = { provinces: [{ id: 'AB' }, { id: 'BC' }, { id: 'MB' }], federal: 1 }
+    expect(getProvinceDescription(holidayStub)).toMatch(
+      'Observed by AB, BC, MB, and federal industries.',
+    )
   })
 })

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -1,4 +1,10 @@
-const { array2Obj, nextHoliday, upcomingHolidays, getCurrentHolidayYear } = require('../index')
+const {
+  array2Obj,
+  nextHoliday,
+  upcomingHolidays,
+  getCurrentHolidayYear,
+  isProvinceId,
+} = require('../index')
 const holidays = require('./data.skip')
 
 describe('Test array2Obj', () => {
@@ -111,5 +117,19 @@ describe('Test getCurrentHolidayYear', () => {
   test('returns 2020 for December 31st, 2019', () => {
     mockDate('2019-12-31')
     expect(getCurrentHolidayYear()).toEqual(2020)
+  })
+})
+
+describe('Test isProvinceId', () => {
+  test('returns true for a real province id', () => {
+    expect(isProvinceId('AB')).toBe(true)
+  })
+
+  test('returns true for a real province id (lowercase)', () => {
+    expect(isProvinceId('ab')).toBe(true)
+  })
+
+  test('returns false for a non-province id', () => {
+    expect(isProvinceId('hawaii')).toBe(false)
   })
 })

--- a/src/utils/ics.js
+++ b/src/utils/ics.js
@@ -17,7 +17,29 @@ const endDate = dateString =>
     .split('-')
 
 /**
- * Returns a description string for .ics files
+ * Returns a title string from a holiday obj to use for .ics files
+ * If a national holiday, it returns the title string unmodified
+ * If not a national holiday, it returns the title string with the ids of the
+ * observing holidays (including "Federal") in brackets
+ *
+ * ie, "Boxing Day (ON, Federal)"
+ *
+ * @param {obj} holiday a holiday object containing 'provinces' and 'nameEn' keys
+ */
+const getTitle = holiday => {
+  if (!holiday.provinces || holiday.provinces.length === 13) {
+    return holiday.nameEn
+  }
+
+  let provinceIds = []
+  holiday.provinces.map(p => provinceIds.push(p.id))
+  holiday.federal && provinceIds.push('Federal')
+
+  return `${holiday.nameEn} (${provinceIds.join(', ')})`
+}
+
+/**
+ * Returns a description string to use for .ics files
  * If a national holiday, returns "National holiday" else a warning that the holiday isn't observed everywhere
  * @param {obj} holiday a holiday object containing a 'provinces' key
  */
@@ -30,4 +52,5 @@ module.exports = {
   startDate,
   endDate,
   getDescription,
+  getTitle,
 }

--- a/src/utils/ics.js
+++ b/src/utils/ics.js
@@ -1,0 +1,33 @@
+const addDays = require('date-fns/addDays')
+
+/**
+ * Takes an ISO-formatted date string (1990-10-08), and returns an array with [year, month, day]
+ * @param {string} dateString an ISO-formatted date string (1990-10-08)
+ */
+const startDate = dateString => dateString.split('-')
+
+/**
+ * Takes an ISO-formatted date string (1990-10-08), and returns an array with the [year, month, day] of the NEXT day
+ * @param {*} dateString an ISO-formatted date string (1990-10-08)
+ */
+const endDate = dateString =>
+  addDays(new Date(dateString), 1)
+    .toISOString()
+    .substring(0, 10)
+    .split('-')
+
+/**
+ * Returns a description string for .ics files
+ * If a national holiday, returns "National holiday" else a warning that the holiday isn't observed everywhere
+ * @param {obj} holiday a holiday object containing a 'provinces' key
+ */
+const getDescription = holiday =>
+  holiday.provinces && holiday.provinces.length === 13
+    ? 'National holiday'
+    : 'This is not a national holiday; it may not be observed in your region'
+
+module.exports = {
+  startDate,
+  endDate,
+  getDescription,
+}

--- a/src/utils/ics.js
+++ b/src/utils/ics.js
@@ -43,14 +43,38 @@ const getTitle = holiday => {
  * If a national holiday, returns "National holiday" else a warning that the holiday isn't observed everywhere
  * @param {obj} holiday a holiday object containing a 'provinces' key
  */
-const getDescription = holiday =>
+const getNationalDescription = holiday =>
   holiday.provinces && holiday.provinces.length === 13
     ? 'National holiday'
     : 'This is not a national holiday; it may not be observed in your region'
 
+/**
+ * Returns a description string to use for .ics files
+ * If a national holiday, returns "National holiday" else a warning that the holiday isn't observed everywhere
+ * @param {obj} holiday a holiday object containing a 'provinces' key
+ */
+const getProvinceDescription = holiday => {
+  if (!holiday.provinces || holiday.provinces.length === 13) {
+    return 'National holiday'
+  }
+
+  let provinceIds = []
+  holiday.provinces.length === 1
+    ? holiday.provinces.map(p => provinceIds.push(p.nameEn))
+    : holiday.provinces.map(p => provinceIds.push(p.id))
+
+  holiday.federal && provinceIds.push('federal industries')
+  if (provinceIds.length > 1) {
+    provinceIds[provinceIds.length - 1] = `and ${provinceIds[provinceIds.length - 1]}`
+  }
+
+  return `Observed by ${provinceIds.length === 2 ? provinceIds.join(' ') : provinceIds.join(', ')}.`
+}
+
 module.exports = {
   startDate,
   endDate,
-  getDescription,
+  getNationalDescription,
+  getProvinceDescription,
   getTitle,
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -52,13 +52,25 @@ const dbmw = (db, cb) => {
   }
 }
 
+// returns true if province ID exists else false. Case insensitive.
+const isProvinceId = provinceId => {
+  return ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'].includes(
+    provinceId.toUpperCase(),
+  )
+}
+
 // middleware for returning "province id doesn't exist" errors
 const checkProvinceIdErr = (req, res, next) => {
-  const provinceMsg =
-    'Accepted province IDs are: [AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT].'
-  if (!res.locals.rows.length) {
+  const provinceId = req.params.provinceId
+
+  if (!isProvinceId(provinceId)) {
     res.status(400)
-    next(createError(400, `Error: No province with id “${req.params.provinceId}”. ${provinceMsg}`))
+    next(
+      createError(
+        400,
+        `Error: No province with id “${provinceId}”. Accepted province IDs are: [AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT].`,
+      ),
+    )
   }
 
   next()
@@ -161,6 +173,7 @@ module.exports = {
   gaIfProd,
   array2Obj,
   dbmw,
+  isProvinceId,
   checkProvinceIdErr,
   nextHoliday,
   upcomingHolidays,


### PR DESCRIPTION
Similarly to on gov.uk/bank-holidays, added a button that creates an `.ics` file you can download and then add holidays to your calendar. reused the button styling that I used to have, so nice to see that being used.

slightly different behaviour based on whether or not we're on the root domain or one of the province domains, but that's not a user problem.

took longer than I thought it would, but it works pretty well.

## screenshot

<img width="1342" alt="Screen Shot 2020-01-12 at 1 09 20 AM" src="https://user-images.githubusercontent.com/2454380/72214842-6af14b00-34d8-11ea-879c-d4f6efabcd16.png">
