### PR TITLE
Page 4 downloads

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,13 +7,15 @@ This is an API that lists
 - all 27 public holidays in Canada
 - all 13 provinces and territories in Canada
 - which provinces/territories observe which holidays
-- (TODO: which holidays are federal holidays)
+- which holidays are federal holidays
+- returns holidays for years: 2019, 2020, 2021
+- (TODO: more years)
 
 I scraped the data from [the Canadian holidays page on Wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_Canada), so if you notice an issue, please edit the page yourself and then [email me](mailto:paul@pcraig3.ca) so that I know.
 
 This is a node API, so it's pretty straightforward. Using an SQL migrations file, we put all our data into an in-memory SQLite database and then we do reads.
 
-The [Government of Canada API guidance](https://www.canada.ca/en/government/publicservice/modernizing/government-canada-standards-apis.html) wants a slightly more rigourous API design, but "design with users" is actually the first rule and none of them have complained yet.
+The [Government of Canada API guidance](https://www.canada.ca/en/government/publicservice/modernizing/government-canada-standards-apis.html) wants a slightly more rigourous API design, but "design with users" is actually the first rule and none of them have complained yet. ([Be the first](mailto:paul@pcraig3.ca)!)
 
 ## Docs
 
@@ -27,6 +29,15 @@ None of the fields ever return `null` values.
 - [`/api/v1/provinces/{id}`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1provincesid--get-one-province-or-territory)
 - [`/api/v1/holidays`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1holidays--get-all-holidays)
 - [`/api/v1/holidays/{id}`](https://github.com/pcraig3/hols/blob/master/API.md#v1holidaysid--get-one-holiday)
+
+### Filters
+
+There are 2 filter values you can use. Probably not on the root route but on others they will work.
+
+1. `?year=2019|2020|2021`. Defaults to current year.
+2. `?federal=true|false`. `true` returns only federal holidays; `false` returns _everything but_ federal holidays.
+
+You can combine them and they will work (eg, `/api/v1/holidays?year=2021&federal=true`).
 
 ### Routes
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -21,7 +21,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   border-bottom: none;
   box-shadow: 0 4px ${accent};
 
-  color: ${accent};
+  color: ${accent} !important;
   padding: 3px 5px;
   cursor: pointer;
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -5,9 +5,26 @@ const Nav = require('./Nav')
 const SkipLink = require('./SkipLink')
 
 const linkStyles = color => css`
-  a:focus {
-    outline: 3px solid ${color ? theme.color[color].focus : theme.color.focus};
-    outline-offset: 5px;
+  a,
+  a:visited {
+    color: ${color ? theme.color[color].accent : theme.color.red};
+
+    &.up-arrow::after {
+      content: ' ↑';
+    }
+
+    &.down-arrow::after {
+      content: ' ↓';
+    }
+
+    &.right-arrow::after {
+      content: ' →';
+    }
+
+    &:focus {
+      outline: 3px solid ${color ? theme.color[color].focus : theme.color.focus};
+      outline-offset: 5px;
+    }
   }
 
   details summary:focus,

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -44,9 +44,14 @@ const styles = css`
 const linkStyles = css`
   list-style: none;
   margin: 0;
+  padding-left: ${theme.space.sm};
 
   li {
     margin-top: ${theme.space.xs};
+
+    &:first-of-type {
+      margin-top: ${theme.space.sm};
+    }
 
     a {
       color: ${theme.color.grey};
@@ -63,6 +68,10 @@ const linkStyles = css`
       margin-left: ${theme.space.md};
       margin-top: 0;
 
+      &:first-of-type {
+        margin-top: 0;
+      }
+
       a.active {
           font-weight: 500;
         }
@@ -76,6 +85,7 @@ const NavLinks = ({ route }) => {
     <ul class=${linkStyles}>
       <li><a class=${route === '/federal' ? 'active' : ''} href="/federal">Federal holidays</a></li>
       <li><a class=${route === '/about' ? 'active' : ''} href="/about">About</a></li>
+      <li><a class=${route === '/api' ? 'active' : ''} href="/api">API</a></li>
       <li>
         <a class=${route === '/feedback' ? 'active' : ''} href="/feedback">Feedback</a>
       </li>

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -11,6 +11,10 @@ const summaryRow = css`
     padding-top: 0;
   }
 
+  &:last-of-type {
+    border-bottom: 2px solid ${theme.color.greyLight};
+  }
+
   &.repeatDate {
     border-top: none;
     padding-top: ${theme.space.xs};
@@ -57,6 +61,14 @@ const summaryRow = css`
       .value,
       .value2 {
         border-top: none;
+      }
+    }
+
+    &:last-of-type {
+      .key,
+      .value,
+      .value2 {
+        border-bottom: 2px solid ${theme.color.greyLight};
       }
     }
 

--- a/src/components/__tests__/Nav.test.js
+++ b/src/components/__tests__/Nav.test.js
@@ -20,7 +20,7 @@ describe('Nav', () => {
     expect($('nav').length).toBe(1)
     // links appear twice because technically we have 2 menus
     expect($('nav .links').text()).toEqual(
-      'MenuFederal holidaysAboutFeedbackFederal holidaysAboutFeedback',
+      'MenuFederal holidaysAboutAPIFeedbackFederal holidaysAboutAPIFeedback',
     )
   })
 

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -1,0 +1,72 @@
+const { html } = require('../utils')
+const Layout = require('../components/Layout.js')
+const Content = require('../components/Content.js')
+
+const Feedback = () =>
+  html`
+    <${Layout}>
+      <${Content}>
+        <h1>Holidays API</h1>
+        <p>
+          <a href="/">canada-holidays.ca</a> is powered by a JSON API that returns Canada’s
+          statutory holidays, and you can use it too.${' '}
+        </p>
+        <p>
+          <span aria-hidden="true">👉</span>${' '}
+
+          <a href="https://canada-holidays.ca/api/v1/" target="_blank"
+            >https://canada-holidays.ca/api/v1/</a
+          >
+          ${' '}<span aria-hidden="true">👈</span>
+        </p>
+        <p>Features:</p>
+        <ul>
+          <li>Return holidays with associated regions</li>
+          <li>Return regions with associated holidays</li>
+          <li>Filter by federal holidays</li>
+          <li>Filter by national holidays</li>
+          <li>Free forever</li>
+          <li>It’s pretty good</li>
+          <li>Kind of bilingual (EN & FR)</li>
+          <li>
+            Nearly compliant with the${' '}
+            <a
+              href="https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/government-canada-standards-apis.html"
+              target="_blank"
+              >Government of Canada Standards on APIs</a
+            >${' '} (heck yes <span aria-hidden="true">🤙</span>)
+          </li>
+          <li>
+            <a href="https://github.com/pcraig3/hols" target="_blank">Open source</a> which is cool
+            if you’re a nerd
+          </li>
+        </ul>
+        <p>Definitely use it for your billions of dollars mission-critical system.</p>
+
+        <h2>Documentation</h2>
+        <p>
+          <a
+            title="API documentation"
+            href="https://github.com/pcraig3/hols/blob/master/API.md"
+            target="_blank"
+            >Documentation is here</a
+          >; it’s pretty good. (see point 5 above.)
+        </p>
+
+        <h2>Citations</h2>
+        <p>
+          Scraped the data from the Wikipedia article “<a
+            href="https://en.wikipedia.org/wiki/Public_holidays_in_Canada"
+            >Public holidays in Canada</a
+          >” that knows about which provinces observe which holidays and vice-versa. And${' '}
+          <em>then</em>${' '}I even${' '}
+          <a href="https://github.com/pcraig3/hols/#citations" title="Citations" target="_blank"
+            >double-checked</a
+          >${' '} so we should be all good.
+        </p>
+        <p>Mistaeks do happen, so <a href="/feedback">lemme know</a>.<//>
+      <//>
+    <//>
+  `
+
+module.exports = Feedback

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -4,7 +4,7 @@ const Content = require('../components/Content.js')
 
 const Feedback = () =>
   html`
-    <${Layout}>
+    <${Layout} route="/api">
       <${Content}>
         <h1>Holidays API</h1>
         <p>

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -35,10 +35,7 @@ const About = ({ data: { nextHoliday } }) =>
         </p>
 
         <h2>“Something is wrong”</h2>
-        <p>
-          Leave me some <a href="/feedback">/feedback</a> and I’ll do my best. I will at least tell
-          you if I can’t fix it.
-        </p>
+        <p>Leave me some <a href="/feedback">/feedback</a> and I’ll do my best.</p>
 
         <h2>Me</h2>
         <p>

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -7,14 +7,20 @@ const About = ({ data: { nextHoliday } }) =>
     <${Layout} route="/about">
       <${Content}>
         <h1>About</h1>
-
         <p>
           Work sucks, I know. But until we get the post-work future we all deserve,${' '}
           <a href="/">${nextHoliday.nameEn}</a> is what we have to look forward to.
         </p>
 
-        <h2>API</h2>
-        <p>Yes,${' '}<a href="/api" target="_blank">there’s an API</a>.</p>
+        <h2>“I want to add all the holidays to my calendar”</h2>
+        <p>
+          Heck yes you do! And${' '}
+          <a
+            href="/add-holidays-to-calendar"
+            title="you can add Canada’s 2020 holidays to your calendar"
+            >you can</a
+          >!
+        </p>
 
         <h2>“Something is wrong”</h2>
         <p>Leave me some <a href="/feedback">/feedback</a> and I’ll do my best.</p>
@@ -23,7 +29,9 @@ const About = ({ data: { nextHoliday } }) =>
         <p>
           Hello, my name is${' '}
           <a class="pcraig3" href="https://pcraig3.ca" title="Paul Craig" target="_blank">Paul</a
-          >${' '} and I am paying for this site for some reason.
+          >${' '} and I am paying for this site for some reason.${' '}
+          <a href="https://github.com/pcraig3/hols" target="_blank">Code is on GitHub</a> if you
+          want to “borrow” all my intellectual property.
         </p>
       <//>
     <//>

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -15,24 +15,6 @@ const About = ({ data: { nextHoliday } }) =>
 
         <h2>API</h2>
         <p>Yes,${' '}<a href="/api" target="_blank">there’s an API</a>.</p>
-        <p>
-          Scraped the data from the Wikipedia article “<a
-            href="https://en.wikipedia.org/wiki/Public_holidays_in_Canada"
-            >Public holidays in Canada</a
-          >” that knows about which provinces observe which holidays and vice-versa. And${' '}
-          <em>then</em>${' '}I even${' '}
-          <a href="https://github.com/pcraig3/hols/#citations" title="Citations" target="_blank"
-            >double-checked</a
-          >${' '} so we should be all good.
-        </p>
-        <p>
-          <a
-            title="API documentation"
-            href="https://github.com/pcraig3/hols/blob/master/API.md"
-            target="_blank"
-            >Documentation is here</a
-          >; it should be fairly accurate.
-        </p>
 
         <h2>“Something is wrong”</h2>
         <p>Leave me some <a href="/feedback">/feedback</a> and I’ll do my best.</p>

--- a/src/pages/AddHolidays.js
+++ b/src/pages/AddHolidays.js
@@ -1,0 +1,106 @@
+const { html } = require('../utils')
+const { css } = require('emotion')
+const { theme, visuallyHidden } = require('../styles')
+const Layout = require('../components/Layout.js')
+const Content = require('../components/Content.js')
+const Button = require('../components/Button.js')
+const SummaryTable = require('../components/SummaryTable.js')
+
+const summaryTableStyles = css`
+  @media (${theme.mq.lg}) {
+    .key {
+      width: 55%;
+    }
+
+    .value {
+      width: 45%;
+      text-align: right;
+      padding-right: ${theme.space.xs};
+    }
+  }
+`
+
+const downloadButton = ({ provinceId, year }) => {
+  return html`
+    <${Button}
+      href=${`/ics${provinceId ? `/${provinceId}` : ''}`}
+      download=${`canada-holidays-${provinceId ? `${provinceId}-` : ''}${year}.ics`}
+      color=${provinceId && theme.color[provinceId]}
+      data-event="true"
+      data-label=${`download-holidays-page-${provinceId || 'canada'}`}
+      >Get ${provinceId || 'all'} holidays<//
+    >
+  `
+}
+const createRows = ({ provinces, year }) => {
+  return provinces.map(p => {
+    return {
+      key: p.nameEn,
+      value: downloadButton({ provinceId: p.id, year }),
+      className: summaryTableStyles,
+    }
+  })
+}
+
+const AddHolidays = ({ data: { provinces, year } }) => {
+  return html`
+    <${Layout}>
+      <${Content}>
+        <h1>Add Canada’s ${year} holidays to your calendar</h1>
+        <p>
+          Download Canadian holidays and import them to your Outlook, iCal, or Google Calendar.
+          (There are probably other calendars but those are the main ones.)
+        </p>
+        <p>Adding holidays to your calendar is easy.</p>
+        <ol>
+          <li>You can add all Canadian holidays or just those for your region</li>
+          <li>Click to download an <code>.ics</code> file with the dates</li>
+          <li>Double-click the file (or drag it into your preferred calendar)</li>
+          <li>Done! <span role="img" aria-label="Happy cowboy">🤠</span></li>
+        </ol>
+        <p>
+          You can also just peek at the <a href="/provinces">holidays for your region</a> and add
+          them later.
+        </p>
+
+        <${SummaryTable}
+          title="Download all Canadian statutory holidays"
+          rows=${[
+            { key: 'Canada', value: downloadButton({ year }), className: summaryTableStyles },
+          ]}
+        >
+          <h2>Download all Canadian <span class=${visuallyHidden}>statutory</span> holidays</h2>
+          <p>For the Canadian completist.</p>
+        <//>
+
+        <${SummaryTable}
+          title="Download federally-regulated statutory holidays"
+          rows=${[
+            {
+              key: 'Federal holidays',
+              value: downloadButton({ provinceId: 'federal', year }),
+              className: summaryTableStyles,
+            },
+          ]}
+        >
+          <h2>
+            Download federally-regulated <span class=${visuallyHidden}>statutory</span> holidays
+          </h2>
+          <p>
+            For airline pilots, federal policy wonks, etc.${' '}
+            <a href="/do-federal-holidays-apply-to-me">Find out if federal holidays apply to you</a
+            >.
+          </p>
+        <//>
+
+        <${SummaryTable} title="Regional holidays" rows=${createRows({ provinces, year })}>
+          <h2>Download regional <span class=${visuallyHidden}>statutory</span> holidays</h2>
+          <p>For regular folks or secessionists.</p>
+        <//>
+        <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>
+      <//>
+    <//>
+  `
+}
+
+module.exports = AddHolidays

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -8,28 +8,7 @@ const ProvincePicker = require('../components/ProvincePicker.js')
 const SummaryTable = require('../components/SummaryTable.js')
 const Button = require('../components/Button.js')
 
-const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) => css`
-  a,
-  a:visited {
-    color: ${accent};
-
-    &.up-arrow::after {
-      content: ' ↑';
-    }
-
-    &.down-arrow::after {
-      content: ' ↓';
-    }
-
-    &.right-arrow::after {
-      content: ' →';
-    }
-
-    &:focus {
-      outline-color: ${focus};
-    }
-  }
-
+const styles = ({ accent = theme.color.red } = {}) => css`
   div.past {
     > * {
       opacity: 0.6;

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -3,6 +3,7 @@ const db = require('sqlite')
 const Promise = require('bluebird')
 const app = require('../../server.js')
 const { getCurrentHolidayYear } = require('../../utils')
+const cheerio = require('cheerio')
 
 describe('Test /api responses', () => {
   beforeAll(async () => {
@@ -48,10 +49,21 @@ describe('Test /api responses', () => {
     )
   }
 
-  test('for /api path it should return a 302 status', async () => {
-    const response = await request(app).get('/api/')
-    expect(response.statusCode).toBe(302)
-    expect(response.headers.location).toEqual('/api/v1/')
+  describe('Test /api response', () => {
+    test('it should return 200', async () => {
+      const response = await request(app).get('/api')
+      expect(response.statusCode).toBe(200)
+    })
+
+    test('it should return the h1, title, and meta tag', async () => {
+      const response = await request(app).get('/api')
+      const $ = cheerio.load(response.text)
+      expect($('h1').text()).toEqual('Holidays API')
+      expect($('title').text()).toEqual('Holidays API — Canada statutory holidays')
+      expect($('meta[name="description"]').attr('content')).toEqual(
+        'A free JSON API for Canada’s statutory holidays. Return all holidays or filter by a specific region.',
+      )
+    })
   })
 
   test('for /api/v1/* not found path a 404 status', async () => {

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -126,6 +126,25 @@ describe('Test ui responses', () => {
       })
     })
 
+    describe('Test /add-holidays-to-calendar response', () => {
+      test('it should return 200', async () => {
+        const response = await request(app).get('/add-holidays-to-calendar')
+        expect(response.statusCode).toBe(200)
+      })
+
+      test('it should return the h1, title, and meta tag', async () => {
+        const response = await request(app).get('/add-holidays-to-calendar')
+        const $ = cheerio.load(response.text)
+        expect($('h1').text()).toEqual('Add Canada’s 2020 holidays to your calendar')
+        expect($('title').text()).toEqual(
+          'Add Canada’s 2020 holidays to your calendar — Canada statutory holidays',
+        )
+        expect($('meta[name="description"]').attr('content')).toEqual(
+          'Download Canadian holidays and import them to your Outlook, iCal, or Google Calendar. Add all Canadian statutory holidays or just for your region.',
+        )
+      })
+    })
+
     describe('Test /do-federal-holidays-apply-to-me response', () => {
       test('it should return 200', async () => {
         const response = await request(app).get('/do-federal-holidays-apply-to-me')

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 const db = require('sqlite')
 const createError = require('http-errors')
+const renderPage = require('../pages/_document.js')
 const { dbmw, checkProvinceIdErr } = require('../utils')
 const { getProvincesWithHolidays, getHolidaysWithProvinces } = require('../queries')
 
@@ -36,7 +37,7 @@ router.get('/v1/', (req, res) => {
 
   res.send({
     message:
-      'Hello / Bonjour! Welcome to the Canadian holidays API | Bienvenue dans l’API canadienne des jours fériés',
+      'Hello / Bonjour! Welcome to the Canada Holidays API / Bienvenue dans l’API canadienne des jours fériés',
     _links: {
       self: {
         href: `${protocol}://${req.get('host')}/api/v1/`,
@@ -51,7 +52,19 @@ router.get('/v1/', (req, res) => {
   })
 })
 
-router.get('/', (req, res) => res.redirect(302, '/api/v1/'))
+router.get('/', (req, res) => {
+  return res.send(
+    renderPage({
+      pageComponent: 'API',
+      title: 'Holidays API — Canada statutory holidays',
+      docProps: {
+        meta:
+          'A free JSON API for Canada’s statutory holidays. Return all holidays or filter by a specific region.',
+        path: req.path,
+      },
+    }),
+  )
+})
 
 router.get('*', (req, res) => {
   res.status(404)

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -130,6 +130,22 @@ router.get('/feedback', (req, res) => {
   )
 })
 
+router.get('/add-holidays-to-calendar', dbmw(db, getProvinces), (req, res) => {
+  const year = getCurrentHolidayYear()
+  return res.send(
+    renderPage({
+      pageComponent: 'AddHolidays',
+      title: 'Add Canada’s 2020 holidays to your calendar — Canada statutory holidays',
+      docProps: {
+        meta:
+          'Download Canadian holidays and import them to your Outlook, iCal, or Google Calendar. Add all Canadian statutory holidays or just for your region.',
+        path: req.path,
+      },
+      props: { data: { provinces: res.locals.rows, year } },
+    }),
+  )
+})
+
 router.get('*', (req, res) => {
   res.status(404)
   throw new createError(404, 'Oopsie daisy. Maybe head back to the home page? 👇')


### PR DESCRIPTION
added a couple of new pages:

1. Add holidays to your calendar: how to do it and all the links
2. Holidays API: describes how to use it

mostly the motivation here is that there is no good way to google these things and find them. now there is, but it still needs a sitemap.


