### PR TITLE
no "s" after the apostrophe when the region's name ends in "s"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -135,8 +135,8 @@ const nextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, fede
       <div>
         <h1>
           <div class="h1--intro">
-            ${provinceName}’s next${' '}${federal && 'federal '}<span class=${visuallyHidden}
-              >statutory </span
+            ${provinceName}’${provinceName.slice(-1) === 's' ? '' : 's'}
+            ${' '}next${' '}${federal && 'federal '}<span class=${visuallyHidden}>statutory </span
             >holiday is
           </div>
           <div class="h1--date"><${DateHtml} dateString=${nextHoliday.date} //></div>

--- a/src/components/__tests__/nextHolidayBox.test.js
+++ b/src/components/__tests__/nextHolidayBox.test.js
@@ -14,8 +14,10 @@ const renderNextHolidayBox = props => {
   )
 }
 
-const getProvince = () => {
-  return { id: 'PE', nameEn: 'Prince Edward Island' }
+const getProvince = ({ endsWithS = false } = {}) => {
+  return endsWithS
+    ? { id: 'NT', nameEn: 'Northwest Territories' }
+    : { id: 'PE', nameEn: 'Prince Edward Island' }
 }
 
 const getNextHoliday = () => {
@@ -111,4 +113,22 @@ test('nextHolidayBox displays next holiday properly for a given province', () =>
     )}`,
   )
   expect($('h1 + p').text()).toMatch(/That’s in (about )?(\d\d days|\d month(s)?)/)
+})
+
+test('nextHolidayBox doesn’t put an "s" after the apostrophe for a province that ends in "s"', () => {
+  const nextHoliday = getNextHoliday()
+  delete nextHoliday.provinces
+
+  const $ = renderNextHolidayBox({
+    nextHoliday,
+    provinceId: getProvince({ endsWithS: true }).id,
+    provinceName: getProvince({ endsWithS: true }).nameEn,
+  })
+
+  expect($('div h1').length).toBe(1)
+  expect($('h1').text()).toEqual(
+    `Northwest Territories’ next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(
+      nextHoliday.nameEn,
+    )}`,
+  )
 })


### PR DESCRIPTION
Pretty straightforward.

## screenshot

| before | after |
|--------|-------|
| <img width="624" alt="Screen Shot 2020-02-28 at 1 58 06 AM" src="https://user-images.githubusercontent.com/2454380/75518235-73d9a580-59ce-11ea-9ebe-82271ecbb2d4.png">  |  <img width="610" alt="Screen Shot 2020-02-28 at 1 57 46 AM" src="https://user-images.githubusercontent.com/2454380/75518237-74723c00-59ce-11ea-9a9d-606bb5a58e94.png">  |





