### PR TITLE
Mention federal holidays in the contextual text on the main page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 # TODO
 
-- look at the little subtitle on the main page
-  - bug: add federal holidays to the mix
 - make API to return CSV format
   - page for CSV downloads
 - add holidays by year to the frontend
@@ -18,6 +16,7 @@
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common
+    - bug: add federal holidays to the mix
 - google analytics events capture specific pages
 - de-emphasize the "download" button
   - bug: shim the link button with JS

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - look at the little subtitle on the main page
   - bug: add federal holidays to the mix
-  - make it say "observed in" because it's more common
 - make API to return CSV format
   - page for CSV downloads
 - add holidays by year to the frontend
@@ -18,6 +17,7 @@
 
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
+  - make it say "observed in" because it's more common
 - google analytics events capture specific pages
 - de-emphasize the "download" button
   - bug: shim the link button with JS

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,8 @@
 # TODO
 
+- look at the little subtitle on the main page
+  - bug: add federal holidays to the mix
+  - make it say "observed in" because it's more common
 - make API to return CSV format
   - page for CSV downloads
 - add holidays by year to the frontend
@@ -13,6 +16,8 @@
 
 # DONE
 
+- look at the little subtitle on the main page
+  - bug: only says "celebrated by" for federal holidays
 - google analytics events capture specific pages
 - de-emphasize the "download" button
   - bug: shim the link button with JS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,13 +8,13 @@
 
 <url>
   <loc>https://canada-holidays.ca/</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
@@ -32,31 +32,31 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
@@ -68,49 +68,49 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT</loc>
-  <lastmod>2020-03-07T15:38:23+00:00</lastmod>
+  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -86,7 +86,11 @@ const styles = ({
   }
 `
 
-const renderCelebratingProvinces = provinces => {
+const renderCelebratingProvinces = (provinces) => {
+  if (provinces.length === 0) {
+    return html`<p>Observed by${' '}<a href="/federal">federal industries</a></p> `
+  }
+
   if (provinces.length === 1) {
     return html`
       <p>Celebrated by${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a></p>
@@ -94,18 +98,16 @@ const renderCelebratingProvinces = provinces => {
   }
 
   if (provinces.length === 13) {
-    return html`
-      <p>National holiday</p>
-    `
+    return html`<p>National holiday</p>`
   }
 
-  const isLastProvince = province => province.id === provinces[provinces.length - 1].id
+  const isLastProvince = (province) => province.id === provinces[provinces.length - 1].id
 
   return html`
     <p>
       Celebrated by
       ${provinces.map(
-        p => html`
+        (p) => html`
           ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`}>${p.id}</a
           >${isLastProvince(p) ? '' : ','}
         `,
@@ -114,10 +116,8 @@ const renderCelebratingProvinces = provinces => {
   `
 }
 
-const renderRelativeDate = dateString => {
-  return html`
-    <p>${relativeDate(dateString)}</p>
-  `
+const renderRelativeDate = (dateString) => {
+  return html`<p>${relativeDate(dateString)}</p>`
 }
 
 const nextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, federal }) => {
@@ -146,14 +146,14 @@ const nextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, fede
           ? renderCelebratingProvinces(nextHoliday.provinces)
           : renderRelativeDate(nextHoliday.date)}
         ${federal &&
-          html`
-            <p>
-              <a href="/do-federal-holidays-apply-to-me"
-                >Find out who gets federal${' '}
-                <span class=${visuallyHidden}>statutory </span>holidays</a
-              >
-            </p>
-          `}
+        html`
+          <p>
+            <a href="/do-federal-holidays-apply-to-me"
+              >Find out who gets federal${' '}
+              <span class=${visuallyHidden}>statutory </span>holidays</a
+            >
+          </p>
+        `}
       </div>
     </div>
   `

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -86,31 +86,62 @@ const styles = ({
   }
 `
 
-const renderCelebratingProvinces = (provinces) => {
+const renderObservingProvinces = ({ provinces, federal }) => {
   if (provinces.length === 13) {
     return html`<p>National holiday</p>`
   }
 
   if (provinces.length === 0) {
-    return html`<p>Observed by${' '}<a href="/federal">federal industries</a></p> `
+    return html`<p>Observed by${' '}<a href="/federal">federal industries</a></p>`
   }
 
   if (provinces.length === 1) {
-    return html`
-      <p>Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a></p>
-    `
+    return federal
+      ? html`
+          <p>
+            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+            ${' '}and by${' '}<a href="/federal">federal industries</a>
+          </p>
+        `
+      : html`
+          <p>
+            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+          </p>
+        `
   }
 
   if (provinces.length === 2) {
-    return html`
-      <p>
-        Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a> and
-        ${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn}</a>
-      </p>
-    `
+    return federal
+      ? html`
+          <p>
+            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>,
+            ${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn}</a>${' '}and
+            by${' '}<a href="/federal">federal industries</a>
+          </p>
+        `
+      : html`
+          <p>
+            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+            ${' '}and${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn}</a>
+          </p>
+        `
   }
 
   const isLastProvince = (province) => province.id === provinces[provinces.length - 1].id
+
+  if (federal) {
+    return html`
+      <p>
+        Observed in
+        ${provinces.map(
+          (p) => html`
+            ${' '}<a href=${`/province/${p.id}`}>${p.id}</a>${isLastProvince(p) ? '' : ','}
+          `,
+        )}
+        ${' '}and by${' '}<a href="/federal">federal industries</a>
+      </p>
+    `
+  }
 
   return html`
     <p>
@@ -152,7 +183,10 @@ const nextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, fede
           <div class="h1--name">${nextHoliday.nameEn.replace(/ /g, '\u00a0')}</div>
         </h1>
         ${nextHoliday.provinces && !federal
-          ? renderCelebratingProvinces(nextHoliday.provinces)
+          ? renderObservingProvinces({
+              provinces: nextHoliday.provinces,
+              federal: nextHoliday.federal,
+            })
           : renderRelativeDate(nextHoliday.date)}
         ${federal &&
         html`

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -87,25 +87,34 @@ const styles = ({
 `
 
 const renderCelebratingProvinces = (provinces) => {
+  if (provinces.length === 13) {
+    return html`<p>National holiday</p>`
+  }
+
   if (provinces.length === 0) {
     return html`<p>Observed by${' '}<a href="/federal">federal industries</a></p> `
   }
 
   if (provinces.length === 1) {
     return html`
-      <p>Celebrated by${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a></p>
+      <p>Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a></p>
     `
   }
 
-  if (provinces.length === 13) {
-    return html`<p>National holiday</p>`
+  if (provinces.length === 2) {
+    return html`
+      <p>
+        Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a> and
+        ${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn}</a>
+      </p>
+    `
   }
 
   const isLastProvince = (province) => province.id === provinces[provinces.length - 1].id
 
   return html`
     <p>
-      Celebrated by
+      Observed in
       ${provinces.map(
         (p) => html`
           ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`}>${p.id}</a

--- a/src/components/__tests__/nextHolidayBox.test.js
+++ b/src/components/__tests__/nextHolidayBox.test.js
@@ -44,10 +44,26 @@ test('nextHolidayBox displays next holiday properly for Canada', () => {
   expect($('h1').text()).toEqual(
     `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
-  expect($('h1 + p').text()).toEqual('Celebrated by Prince Edward Island')
+  expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island')
 })
 
-test('nextHolidayBox uses province IDs when more than 1 province exists', () => {
+test('nextHolidayBox uses full province name when 2 provinces exist', () => {
+  const nextHoliday = getNextHoliday()
+  nextHoliday.provinces = [
+    { id: 'PE', nameEn: 'Prince Edward Island' },
+    { id: 'AB', nameEn: 'Alberta' },
+  ]
+
+  const $ = renderNextHolidayBox({ nextHoliday })
+
+  expect($('div h1').length).toBe(1)
+  expect($('h1').text()).toEqual(
+    `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
+  )
+  expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island and Alberta')
+})
+
+test('nextHolidayBox uses province IDs when more than 2 province exists', () => {
   const nextHoliday = getNextHoliday()
   nextHoliday.provinces = [{ id: 'PE', nameEn: 'Prince Edward Island' }, { id: 'AB' }, { id: 'QC' }]
 
@@ -57,7 +73,7 @@ test('nextHolidayBox uses province IDs when more than 1 province exists', () => 
   expect($('h1').text()).toEqual(
     `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
-  expect($('h1 + p').text()).toEqual('Celebrated by PE, AB, and QC')
+  expect($('h1 + p').text()).toEqual('Observed in PE, AB, and QC')
 })
 
 test('nextHolidayBox refers to federal holidays when no provinces exist', () => {

--- a/src/components/__tests__/nextHolidayBox.test.js
+++ b/src/components/__tests__/nextHolidayBox.test.js
@@ -15,21 +15,11 @@ const getProvince = ({ endsWithS = false } = {}) => {
 }
 
 const getNextHoliday = ({ federal } = {}) => {
-  if (federal) {
-    return {
-      id: 8,
-      date: '2020-04-13',
-      nameEn: 'Easter Monday',
-      federal: 1,
-      provinces: [],
-    }
-  }
-
   return {
     id: 20,
     date: '2019-08-16',
     nameEn: 'Gold Cup Parade Day',
-    federal: 0,
+    federal: federal ? 1 : 0,
     provinces: [getProvince()],
   }
 }
@@ -44,48 +34,68 @@ test('nextHolidayBox displays next holiday properly for Canada', () => {
   expect($('h1').text()).toEqual(
     `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
-  expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island')
 })
 
-test('nextHolidayBox uses full province name when 2 provinces exist', () => {
-  const nextHoliday = getNextHoliday()
-  nextHoliday.provinces = [
-    { id: 'PE', nameEn: 'Prince Edward Island' },
-    { id: 'AB', nameEn: 'Alberta' },
-  ]
+describe('nextHolidayBox subtext', () => {
+  test('uses full province name when one province exists', () => {
+    const nextHoliday = getNextHoliday()
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island')
+  })
 
-  const $ = renderNextHolidayBox({ nextHoliday })
+  test('uses full province names when 2 provinces exist', () => {
+    const nextHoliday = getNextHoliday()
+    nextHoliday.provinces = [
+      { id: 'PE', nameEn: 'Prince Edward Island' },
+      { id: 'AB', nameEn: 'Alberta' },
+    ]
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island and Alberta')
+  })
 
-  expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
-  )
-  expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island and Alberta')
-})
+  test('uses province IDs when more than 2 province exist', () => {
+    const nextHoliday = getNextHoliday()
+    nextHoliday.provinces = [
+      { id: 'PE', nameEn: 'Prince Edward Island' },
+      { id: 'AB' },
+      { id: 'QC' },
+    ]
 
-test('nextHolidayBox uses province IDs when more than 2 province exists', () => {
-  const nextHoliday = getNextHoliday()
-  nextHoliday.provinces = [{ id: 'PE', nameEn: 'Prince Edward Island' }, { id: 'AB' }, { id: 'QC' }]
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed in PE, AB, and QC')
+  })
 
-  const $ = renderNextHolidayBox({ nextHoliday })
+  test('nextHolidayBox refers only to federal holidays when no provinces exist', () => {
+    const nextHoliday = getNextHoliday({ federal: true })
+    nextHoliday.provinces = []
 
-  expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
-  )
-  expect($('h1 + p').text()).toEqual('Observed in PE, AB, and QC')
-})
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed by federal industries')
+  })
 
-test('nextHolidayBox refers to federal holidays when no provinces exist', () => {
-  const nextHoliday = getNextHoliday({ federal: true })
+  test('uses full province name and "federal" message when one province exists', () => {
+    const nextHoliday = getNextHoliday({ federal: true })
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island and by federal industries')
+  })
 
-  const $ = renderNextHolidayBox({ nextHoliday })
+  test('uses full province names and "federal" message when 2 provinces exist', () => {
+    const nextHoliday = getNextHoliday({ federal: true })
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed in Prince Edward Island and by federal industries')
+  })
 
-  expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Canada’s next statutory holiday is${sp2nbsp('April 13')}${sp2nbsp(nextHoliday.nameEn)}`,
-  )
-  expect($('h1 + p').text()).toEqual('Observed by federal industries')
+  test('uses province IDs and "federal" message when more than 2 provinces exist', () => {
+    const nextHoliday = getNextHoliday({ federal: true })
+    nextHoliday.provinces = [
+      { id: 'PE', nameEn: 'Prince Edward Island' },
+      { id: 'AB' },
+      { id: 'QC' },
+    ]
+
+    const $ = renderNextHolidayBox({ nextHoliday })
+    expect($('h1 + p').text()).toEqual('Observed in PE, AB, QC and by federal industries')
+  })
 })
 
 test('nextHolidayBox refers to federal holidays when "federal" variable is passed in', () => {

--- a/src/components/__tests__/nextHolidayBox.test.js
+++ b/src/components/__tests__/nextHolidayBox.test.js
@@ -4,14 +4,8 @@ const { html } = require('../../utils')
 
 const NextHolidayBox = require('../NextHolidayBox.js')
 
-const renderNextHolidayBox = props => {
-  return cheerio.load(
-    render(
-      html`
-        <${NextHolidayBox} ...${props} //>
-      `,
-    ),
-  )
+const renderNextHolidayBox = (props) => {
+  return cheerio.load(render(html` <${NextHolidayBox} ...${props} //> `))
 }
 
 const getProvince = ({ endsWithS = false } = {}) => {
@@ -20,7 +14,17 @@ const getProvince = ({ endsWithS = false } = {}) => {
     : { id: 'PE', nameEn: 'Prince Edward Island' }
 }
 
-const getNextHoliday = () => {
+const getNextHoliday = ({ federal } = {}) => {
+  if (federal) {
+    return {
+      id: 8,
+      date: '2020-04-13',
+      nameEn: 'Easter Monday',
+      federal: 1,
+      provinces: [],
+    }
+  }
+
   return {
     id: 20,
     date: '2019-08-16',
@@ -30,7 +34,7 @@ const getNextHoliday = () => {
   }
 }
 
-const sp2nbsp = str => str.replace(/ /g, '\u00a0')
+const sp2nbsp = (str) => str.replace(/ /g, '\u00a0')
 
 test('nextHolidayBox displays next holiday properly for Canada', () => {
   const nextHoliday = getNextHoliday()
@@ -54,6 +58,18 @@ test('nextHolidayBox uses province IDs when more than 1 province exists', () => 
     `Canada’s next statutory holiday is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
   expect($('h1 + p').text()).toEqual('Celebrated by PE, AB, and QC')
+})
+
+test('nextHolidayBox refers to federal holidays when no provinces exist', () => {
+  const nextHoliday = getNextHoliday({ federal: true })
+
+  const $ = renderNextHolidayBox({ nextHoliday })
+
+  expect($('div h1').length).toBe(1)
+  expect($('h1').text()).toEqual(
+    `Canada’s next statutory holiday is${sp2nbsp('April 13')}${sp2nbsp(nextHoliday.nameEn)}`,
+  )
+  expect($('h1 + p').text()).toEqual('Observed by federal industries')
 })
 
 test('nextHolidayBox refers to federal holidays when "federal" variable is passed in', () => {

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -83,7 +83,7 @@ const getTitleString = (provinceName, federal, year) => {
 }
 
 const createRows = (holidays, federal) => {
-  const _provinces = holiday => {
+  const _provinces = (holiday) => {
     if (holiday.provinces.length === 13) {
       return 'National holiday'
     }
@@ -111,11 +111,9 @@ const createRows = (holidays, federal) => {
   const today = new Date(Date.now()).toISOString().slice(0, 10)
   var previousDate = null
 
-  return holidays.map(holiday => {
+  return holidays.map((holiday) => {
     const row = {
-      key: html`
-        <${DateHtml} dateString=${holiday.date} weekday=${true} //>
-      `,
+      key: html` <${DateHtml} dateString=${holiday.date} weekday=${true} //> `,
       value: holiday.nameEn,
     }
 
@@ -132,17 +130,6 @@ const createRows = (holidays, federal) => {
     previousDate = holiday.date
     return row
   })
-}
-
-const ifPastHolidays = (holidays = []) => {
-  // there must be at least 6 past holidays before the button appears
-  const minimum = 6
-  const today = new Date(Date.now()).toISOString().slice(0, 10)
-  if (!holidays[minimum]) {
-    return false
-  }
-
-  return holidays[minimum].date < today
 }
 
 const Province = ({
@@ -194,10 +181,6 @@ const Province = ({
             <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>
           </div>
         </section>
-        ${ifPastHolidays(holidays) &&
-          html`
-            <script src="/js/province.js"></script>
-          `}
       </div>
     <//>
   `


### PR DESCRIPTION
Very small changes, but one real bug.

- Say "observed in" now instead of "celebrated by" (most days off aren't 'celebrations', as such)
- If there are 2 provinces, list their full names (previously it was IDs)
- Added "federal industries" as a thing — should have done it before Easter but you know I'm crazy buzy

Example 👇 

<img width="625" alt="image" src="https://user-images.githubusercontent.com/2454380/79419914-c6265400-7f85-11ea-9007-dbc57001c1c4.png">
