### PR TITLE
Redirect current year

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,9 @@
   - federal
   - 2022/2018
   - redirects query param
-  - redirect current year?
   - add new pages to sitemap
   - don't be grey for past holidays on dedicated pages
+- put "download" button/link onto other year pages
 - add picker for year
 - make API to return CSV format
   - page for CSV downloads
@@ -24,6 +24,7 @@
   - provinces
   - allowed years in global var
   - tests for responses
+  - redirect current year
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@
   - 2022/2018
   - redirects query param
   - add new pages to sitemap
-  - don't be grey for past holidays on dedicated pages
 - put "download" button/link onto other year pages
 - add picker for year
 - make API to return CSV format
@@ -25,6 +24,7 @@
   - allowed years in global var
   - tests for responses
   - redirect current year
+  - don't be grey for past holidays on dedicated pages
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
   - canada
   - federal
   - 2022/2018
-  - redirects query param
   - add new pages to sitemap
 - put "download" button/link onto other year pages
 - add picker for year
@@ -25,6 +24,7 @@
   - tests for responses
   - redirect current year
   - don't be grey for past holidays on dedicated pages
+  - redirects query param
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "1.9.0-alpha",
+  "version": "1.9.1-alpha",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -84,7 +84,7 @@ const getTitleString = (provinceName, federal, year) => {
   `
 }
 
-const createRows = (holidays, federal) => {
+const createRows = (holidays, federal, isCurrentYear) => {
   const _provinces = (holiday) => {
     if (holiday.provinces.length === 13) {
       return 'National holiday'
@@ -123,7 +123,9 @@ const createRows = (holidays, federal) => {
       row.value2 = _provinces(holiday)
     }
 
-    row.className = holiday.date < today ? 'past' : 'upcoming'
+    if (isCurrentYear) {
+      row.className = holiday.date < today ? 'past' : 'upcoming'
+    }
 
     if (previousDate === holiday.date) {
       row.className += ' repeatDate'
@@ -145,6 +147,7 @@ const Province = ({
   } = {},
 }) => {
   const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
+  const isCurrentYear = !!nextHoliday
   return html`
     <${Layout} color=${federal ? 'federal' : provinceId}>
       <div class=${provinceIdOrFederal ? styles(theme.color[provinceIdOrFederal]) : styles()}>
@@ -157,7 +160,7 @@ const Province = ({
           <div class=${insideContainer}>
             <${SummaryTable}
               title=${getTitleString(provinceName, federal, year)}
-              rows=${createRows(holidays, federal)}
+              rows=${createRows(holidays, federal, isCurrentYear)}
             >
               ${nextHoliday &&
               html` <div class=${titleStyles}>

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -38,6 +38,15 @@ router.get('/', dbmw(db, getHolidaysWithProvinces), (req, res) => {
 router.get(
   '/province/:provinceId',
   checkProvinceIdErr,
+  (req, res, next) => {
+    const year = req.query.year && parseInt(req.query.year)
+    // redirect allowed years (not current year) to /province/:provinceId/:year endpoint
+    if (getCurrentHolidayYear() !== parseInt(req.query.year) && ALLOWED_YEARS.includes(year)) {
+      return res.redirect(`/province/${req.params.provinceId}/${req.query.year}`)
+    }
+
+    next()
+  },
   dbmw(db, getProvincesWithHolidays),
   (req, res) => {
     const year = getCurrentHolidayYear()

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -68,19 +68,22 @@ router.get(
   },
   checkProvinceIdErr,
   checkYearErr,
+  (req, res, next) => {
+    // redirect current year to the /province/:provinceId endpoint
+    if (getCurrentHolidayYear() === parseInt(req.query.year)) {
+      return res.redirect(`/province/${req.params.provinceId}`)
+    }
+
+    next()
+  },
   dbmw(db, getProvincesWithHolidays),
   (req, res) => {
     // if the year value isn't in ALLOWED_YEARS, it will be caught by "checkYearErr"
     const year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
 
-    const isCurrentYear = getCurrentHolidayYear() === year
-    const { holidays, nextHoliday, nameEn: provinceName, id: provinceId } = res.locals.rows[0]
+    const { holidays, nameEn: provinceName, id: provinceId } = res.locals.rows[0]
 
     let meta = `See all statutory holidays in ${provinceName}, Canada in ${year}.`
-
-    if (isCurrentYear) {
-      meta = `${provinceId}’s next stat holiday is ${getMeta(nextHoliday)}. ${meta}`
-    }
 
     return res.send(
       renderPage({
@@ -90,7 +93,7 @@ router.get(
         props: {
           data: {
             holidays,
-            nextHoliday: isCurrentYear ? nextHoliday : undefined,
+            nextHoliday: undefined,
             provinceName,
             provinceId,
             year,


### PR DESCRIPTION
This PR does a few little fixup-type things.

1. Adds a redirect for "year" pages from the current year to the "next holiday" page. eg, `/province/ON/2020` becomes `/province/ON`. Maybe there's a better way to handle this but this will do.

2. Adds a redirect for whitelisted "year" query vars from the "next holiday" page to the appropriate year page. eg, `/province/ON?year=2021` becomes `/province/ON/2021`. If the param is the current year or doesn't make sense, we just leave it there. 

3. Removes the faded "grey" cell headings for holidays on "year" pages. Of course 2019's holidays are past holidays — but that's not relevant right now.