### PR TITLE
Years federal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - add holidays by year to the frontend
   - canada
-  - federal
   - 2022/2018
   - Add years to dates on years pages
   - add new pages to sitemap
@@ -26,6 +25,7 @@
   - redirect current year
   - don't be grey for past holidays on dedicated pages
   - redirects query param
+  - federal
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common

--- a/TODO.md
+++ b/TODO.md
@@ -4,12 +4,13 @@
   - canada
   - federal
   - 2022/2018
+  - Add years to dates on years pages
   - add new pages to sitemap
 - put "download" button/link onto other year pages
 - add picker for year
 - make API to return CSV format
   - page for CSV downloads
-- sticky header?
+- swagger api docs?
 - add a print button?
 - https://matthewsmith.io/blog/how-to-set-up-cache-busting-in-express
 - list of holidays

--- a/src/dates/index.js
+++ b/src/dates/index.js
@@ -8,7 +8,7 @@ const differenceInDays = require('date-fns/differenceInDays')
 const startOfDay = require('date-fns/startOfDay')
 const formatDistance = require('date-fns/formatDistance')
 
-const _getISODayInt = weekday => {
+const _getISODayInt = (weekday) => {
   if (weekday === 'Monday') {
     return 1
   }
@@ -62,7 +62,7 @@ const _getDayCount = ({ position, weekday, anchorDate }) => {
   }
 }
 
-const _parseRelativeDates = dateString => {
+const _parseRelativeDates = (dateString) => {
   let [weekday, position, ...anchorDate] = dateString.split(' ')
 
   let year = anchorDate[anchorDate.length - 1]
@@ -111,9 +111,9 @@ const getISODate = (dateString, year = new Date(Date.now()).getUTCFullYear()) =>
 }
 
 // 60 minutes * 24 hours = 1440
-const getDateBeforeMidnightFromString = str => addMinutes(new Date(str), 1439)
+const getDateBeforeMidnightFromString = (str) => addMinutes(new Date(str), 1439)
 
-const space2Nbsp = str => str.replace(/ /g, ' ')
+const space2Nbsp = (str) => str.replace(/ /g, ' ')
 
 const displayDate = (dateString, weekday = false) => {
   dateString = getDateBeforeMidnightFromString(dateString)
@@ -122,7 +122,7 @@ const displayDate = (dateString, weekday = false) => {
   return weekday ? `${msg}, ${format(dateString, 'EEEE')}` : msg
 }
 
-const relativeDate = dateString => {
+const relativeDate = (dateString) => {
   const daysOffset = differenceInDays(
     startOfDay(new Date(Date.now())),
     getDateBeforeMidnightFromString(dateString),

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -111,12 +111,13 @@ const createRows = (holidays, federal, isCurrentYear) => {
   }
 
   const today = new Date(Date.now()).toISOString().slice(0, 10)
-  var previousDate = null
+  let previousDate = null
 
   return holidays.map((holiday) => {
     const row = {
       key: html` <${DateHtml} dateString=${holiday.date} weekday=${true} //> `,
       value: holiday.nameEn,
+      className: '',
     }
 
     if (!federal && holiday.provinces) {

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -132,6 +132,41 @@ router.get('/federal', dbmw(db, getHolidaysWithProvinces), (req, res) => {
   )
 })
 
+router.get(
+  '/federal/:year',
+  (req, res, next) => {
+    req.query.year = req.params.year
+    next()
+  },
+  checkYearErr,
+  (req, res, next) => {
+    // redirect current year to the /federal endpoint
+    if (getCurrentHolidayYear() === parseInt(req.query.year)) {
+      return res.redirect('/federal')
+    }
+
+    next()
+  },
+  dbmw(db, getHolidaysWithProvinces),
+  (req, res) => {
+    // if the year value isn't in ALLOWED_YEARS, it will be caught by "checkYearErr"
+    const year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
+
+    const holidays = res.locals.rows
+
+    const meta = `See all federal statutory holidays in Canada in ${year}.`
+
+    return res.send(
+      renderPage({
+        pageComponent: 'Province',
+        title: `Federal statutory holidays in Canada in ${year}`,
+        docProps: { meta, path: req.path },
+        props: { data: { holidays, nextHoliday: undefined, federal: true, year } },
+      }),
+    )
+  },
+)
+
 router.get('/provinces', dbmw(db, getProvinces), (req, res) => {
   return res.send(
     renderPage({

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -9,6 +9,7 @@ const {
   checkProvinceIdErr,
   checkYearErr,
   checkRedirectYear,
+  param2query,
   nextHoliday,
   getCurrentHolidayYear,
 } = require('../utils')
@@ -64,10 +65,7 @@ router.get(
 
 router.get(
   '/province/:provinceId/:year',
-  (req, res, next) => {
-    req.query.year = req.params.year
-    next()
-  },
+  param2query('year'),
   checkProvinceIdErr,
   checkYearErr,
   (req, res, next) => {
@@ -125,10 +123,7 @@ router.get('/federal', checkRedirectYear, dbmw(db, getHolidaysWithProvinces), (r
 
 router.get(
   '/federal/:year',
-  (req, res, next) => {
-    req.query.year = req.params.year
-    next()
-  },
+  param2query('year'),
   checkYearErr,
   (req, res, next) => {
     // redirect current year to the /federal endpoint

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -9,6 +9,7 @@ const {
   checkProvinceIdErr,
   checkYearErr,
   checkRedirectYear,
+  checkRedirectIfCurrentYear,
   param2query,
   nextHoliday,
   getCurrentHolidayYear,
@@ -68,14 +69,7 @@ router.get(
   param2query('year'),
   checkProvinceIdErr,
   checkYearErr,
-  (req, res, next) => {
-    // redirect current year to the /province/:provinceId endpoint
-    if (getCurrentHolidayYear() === parseInt(req.query.year)) {
-      return res.redirect(`/province/${req.params.provinceId}`)
-    }
-
-    next()
-  },
+  checkRedirectIfCurrentYear,
   dbmw(db, getProvincesWithHolidays),
   (req, res) => {
     // if the year value isn't in ALLOWED_YEARS, it will be caught by "checkYearErr"
@@ -125,14 +119,7 @@ router.get(
   '/federal/:year',
   param2query('year'),
   checkYearErr,
-  (req, res, next) => {
-    // redirect current year to the /federal endpoint
-    if (getCurrentHolidayYear() === parseInt(req.query.year)) {
-      return res.redirect('/federal')
-    }
-
-    next()
-  },
+  checkRedirectIfCurrentYear,
   dbmw(db, getHolidaysWithProvinces),
   (req, res) => {
     // if the year value isn't in ALLOWED_YEARS, it will be caught by "checkYearErr"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,7 +18,7 @@ const dbmw = (db, cb) => {
         return req.query.federal
       }
 
-      if (req.path === '/federal') {
+      if (req.path && req.path.startsWith('/federal')) {
         return 'true'
       }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -94,6 +94,18 @@ const checkProvinceIdErr = (req, res, next) => {
   next()
 }
 
+// middleware to redirect to permitted /:year endpoints for whitelisted query strings
+const checkRedirectYear = (req, res, next) => {
+  const year = req.query.year && parseInt(req.query.year)
+  const GOOD_YEARS = ALLOWED_YEARS.filter((y) => y !== getCurrentHolidayYear())
+
+  if (year && GOOD_YEARS.includes(year)) {
+    return res.redirect(`${req.path}/${req.query.year}`)
+  }
+
+  next()
+}
+
 // return a meta tag if a GITHUB_SHA environment variable exists
 const metaIfSHA = () =>
   process.env.GITHUB_SHA &&
@@ -212,6 +224,7 @@ module.exports = {
   isProvinceId,
   checkProvinceIdErr,
   checkYearErr,
+  checkRedirectYear,
   nextHoliday,
   upcomingHolidays,
   getCurrentHolidayYear,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -106,7 +106,18 @@ const checkRedirectYear = (req, res, next) => {
   next()
 }
 
-// copy a request parameter into req.query
+// middleware to redirect current year to the not !/:year endpoint
+const checkRedirectIfCurrentYear = (req, res, next) => {
+  if (getCurrentHolidayYear() === parseInt(req.query.year)) {
+    let urlParts = req.path.split('/')
+    urlParts.pop()
+    return res.redirect(urlParts.join('/'))
+  }
+
+  next()
+}
+
+// middleware to copy a request parameter into req.query
 const param2query = (param) => {
   return (req, res, next) => {
     req.query[param] = req.params[param]
@@ -233,6 +244,7 @@ module.exports = {
   checkProvinceIdErr,
   checkYearErr,
   checkRedirectYear,
+  checkRedirectIfCurrentYear,
   param2query,
   nextHoliday,
   upcomingHolidays,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -106,6 +106,14 @@ const checkRedirectYear = (req, res, next) => {
   next()
 }
 
+// copy a request parameter into req.query
+const param2query = (param) => {
+  return (req, res, next) => {
+    req.query[param] = req.params[param]
+    next()
+  }
+}
+
 // return a meta tag if a GITHUB_SHA environment variable exists
 const metaIfSHA = () =>
   process.env.GITHUB_SHA &&
@@ -225,6 +233,7 @@ module.exports = {
   checkProvinceIdErr,
   checkYearErr,
   checkRedirectYear,
+  param2query,
   nextHoliday,
   upcomingHolidays,
   getCurrentHolidayYear,


### PR DESCRIPTION
Adds federal "years" pages. Just the two years for now. 

Very similar to #32.

## Screenshots

| 2020 (current) | 2019 (new) | 2021 (new) |
|----------------|------------|------------|
|    <img width="1354" alt="Screen Shot 2020-04-20 at 9 28 28 PM" src="https://user-images.githubusercontent.com/2454380/79815200-0bfc6700-834e-11ea-8656-aaf17e1a4275.png">     | <img width="1354" alt="Screen Shot 2020-04-20 at 9 28 33 PM" src="https://user-images.githubusercontent.com/2454380/79815197-0acb3a00-834e-11ea-9ffa-9a21e9c1bc72.png">     | <img width="1354" alt="Screen Shot 2020-04-20 at 9 28 39 PM" src="https://user-images.githubusercontent.com/2454380/79815187-0737b300-834e-11ea-9d68-f32b2eeebd4a.png">       |





