### PR TITLE
add canada years page

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -100,7 +100,7 @@ const checkRedirectYear = (req, res, next) => {
   const GOOD_YEARS = ALLOWED_YEARS.filter((y) => y !== getCurrentHolidayYear())
 
   if (year && GOOD_YEARS.includes(year)) {
-    return res.redirect(`${req.path}/${req.query.year}`)
+    return res.redirect(`${req.path === '/' ? '' : req.path}/${req.query.year}`)
   }
 
   next()
@@ -111,7 +111,7 @@ const checkRedirectIfCurrentYear = (req, res, next) => {
   if (getCurrentHolidayYear() === parseInt(req.query.year)) {
     let urlParts = req.path.split('/')
     urlParts.pop()
-    return res.redirect(urlParts.join('/'))
+    return res.redirect(urlParts.join('/') || '/')
   }
 
   next()


### PR DESCRIPTION
see #34 and #33 for basically the same code.

also did a couple little fixes for the redirect (current) year middlewares. both had to be slightly modified to take the root domain into account.

## Screenshots

| 2020 (current) | 2019 (new) | 2021 (new) |
|----------------|------------|------------|
|    <img width="1397" alt="Screen Shot 2020-04-20 at 11 17 42 PM" src="https://user-images.githubusercontent.com/2454380/79821607-386baf80-835d-11ea-9a9e-49361bba295b.png">     | <img width="1397" alt="Screen Shot 2020-04-20 at 11 17 47 PM" src="https://user-images.githubusercontent.com/2454380/79821605-373a8280-835d-11ea-91aa-e6aeaf3c7024.png">       | <img width="1397" alt="Screen Shot 2020-04-20 at 11 17 51 PM" src="https://user-images.githubusercontent.com/2454380/79821601-343f9200-835d-11ea-8d1f-0b8893b576e6.png">       |







