### PR TITLE
Add a year picker and more years to pick

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,4 @@
-# hols API
+# Canada Holidays API
 
 Canada has public holidays, but when are they? UK people know when [UK bank holidays](https://www.gov.uk/bank-holidays) are — Canadians who can’t yet move to Liverpool still deserve to know when they can sleep in.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # hols
 
-This is a fun little node app for Canada's public holidays. There's a frontend you can look at and an API you can use.
+This is a fun little node app for Canada's statutory holidays. There's a frontend you can look at and an API you can use.
 
 - The frontend is written using [htm](https://github.com/developit/htm) on the server. Very amusing.
-- The backend API is pretty bare-metal: it's using an initial SQLite thing and then it does "db reads" and spits out rows.
+- The backend API is pretty bare-metal: it's using an initial SQLite migration file stored in memory and then it does "db reads" and spits out rows.
 
 ## Using the API
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 - add holidays by year to the frontend
-  - 2022/2018
   - Add years to dates on years pages?
   - add new pages to sitemap
 - put "download" button/link onto other year pages
@@ -34,6 +33,7 @@
   - redirects query param
   - federal
   - canada
+  - 2022/2018
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,7 @@
 # TODO
 
 - add picker for year
-  - make it functional
-  - make it look good on screen sizes
+  - update the picker to know about dates
   - add aria stuff
   - make the JS width happen
   - add some tests
@@ -21,6 +20,9 @@
 
 # DONE
 
+- add picker for year
+  - make it functional
+  - make it look good on screen sizes
 - add holidays by year to the frontend
   - 2021/2019
   - provinces

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,16 @@
 # TODO
 
+- add picker for year
+  - make it functional
+  - make it look good on screen sizes
+  - add aria stuff
+  - make the JS width happen
+  - add some tests
 - add holidays by year to the frontend
-  - canada
   - 2022/2018
   - Add years to dates on years pages?
   - add new pages to sitemap
 - put "download" button/link onto other year pages
-- add picker for year
 - make API to return CSV format
   - page for CSV downloads
 - swagger api docs?
@@ -26,6 +30,7 @@
   - don't be grey for past holidays on dedicated pages
   - redirects query param
   - federal
+  - canada
 - look at the little subtitle on the main page
   - bug: only says "celebrated by" for federal holidays
   - make it say "observed in" because it's more common

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,7 @@
   - make it look good on screen sizes
   - update the picker to know about dates
   - add aria stuff
+  - update the JS change event
 - add holidays by year to the frontend
   - 2021/2019
   - provinces

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 
 # DONE
 
+- allowed province ids in global var
 - add picker for year
   - make it functional
   - make it look good on screen sizes

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 - add picker for year
-  - add aria stuff
   - make the JS width happen
   - add some tests
 - add holidays by year to the frontend
@@ -23,6 +22,7 @@
   - make it functional
   - make it look good on screen sizes
   - update the picker to know about dates
+  - add aria stuff
 - add holidays by year to the frontend
   - 2021/2019
   - provinces

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,5 @@
 # TODO
 
-- add picker for year
-  - make the JS width happen
-  - add some tests
 - add holidays by year to the frontend
   - 2022/2018
   - Add years to dates on years pages?
@@ -24,6 +21,8 @@
   - update the picker to know about dates
   - add aria stuff
   - update the JS change event
+  - make the JS width happen
+  - add some tests
 - add holidays by year to the frontend
   - 2021/2019
   - provinces

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@
 
 # DONE
 
+- more specific name for the API
 - allowed province ids in global var
 - add picker for year
   - make it functional

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 - add picker for year
-  - update the picker to know about dates
   - add aria stuff
   - make the JS width happen
   - add some tests
@@ -23,6 +22,7 @@
 - add picker for year
   - make it functional
   - make it look good on screen sizes
+  - update the picker to know about dates
 - add holidays by year to the frontend
   - 2021/2019
   - provinces

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "1.9.1-alpha",
+  "version": "1.10.0",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/js/picker.js
+++ b/public/js/picker.js
@@ -2,8 +2,15 @@
 var regionButton = document.getElementById('region-select__button');
 regionButton.setAttribute('data-hidden', true);
 
+function addChangeListener(node) {
+  node.addEventListener('change', function (event) {
+    // node[node.selectedIndex].value
+    event.target.form.submit();
+  });
+}
+
 var regionSelect = document.getElementById('region-select');
-regionSelect.addEventListener('change', function (event) {
-  // regionSelect[regionSelect.selectedIndex].value
-  event.target.form.submit()
-})
+addChangeListener(regionSelect);
+
+var yearSelect = document.getElementById('year-select');
+addChangeListener(yearSelect);

--- a/public/js/picker.js
+++ b/public/js/picker.js
@@ -1,4 +1,6 @@
 /* eslint-disable */
+var selectPadding = 40;
+var root = document.documentElement;
 var regionButton = document.getElementById('region-select__button');
 regionButton.setAttribute('data-hidden', true);
 
@@ -14,3 +16,6 @@ addChangeListener(regionSelect);
 
 var yearSelect = document.getElementById('year-select');
 addChangeListener(yearSelect);
+
+var regionSelectWidth = document.getElementById('region-select-width');
+root.style.setProperty('--region-select-width', regionSelectWidth.offsetWidth + selectPadding + "px");

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -32,6 +32,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     box-shadow: 0 4px ${accent};
     border-radius: 0;
 
+    &.hover-color,
     &:hover,
     &:focus {
       box-shadow: 0 4px black;
@@ -47,6 +48,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     }
   }
 
+  &.hover-color,
   &:hover,
   &:focus {
     color: white !important;
@@ -80,6 +82,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     }
   }
 
+  &.hover-color,
   &:hover,
   &:focus {
     svg {
@@ -100,16 +103,18 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   }
 `
 
-const NativeButton = ({ children, color = {}, ...props }) => {
+const NativeButton = ({ children, color = {}, className = '', ...props }) => {
   return html`
-    <button class=${styles(color)} ...${props}>${children}</button>
+    <button class=${`${className ? `${className} ` : ''}${styles(color)}`} ...${props}>
+      ${children}
+    </button>
   `
 }
 
-const LinkButton = ({ children, color = {}, ghost = false, ...props }) => {
+const LinkButton = ({ children, color = {}, className = '', ...props }) => {
   return html`
     <a
-      class=${`${ghost ? 'ghost ' : ''}${styles(color)}`}
+      class=${`${className ? `${className} ` : ''}${styles(color)}`}
       role="button"
       draggable="false"
       ...${props}

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -154,6 +154,7 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
             <${Button}
               type="submit"
               id="region-select__button"
+              className=${'hover-color'}
               style="padding: 6.5px 9px 3.5px 9px; font-weight: 500;"
               color="${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}"
               ><span class="">Submit</span> →<//

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -1,6 +1,6 @@
 const { html, getProvinceIdOrFederalString } = require('../utils')
 const { css } = require('emotion')
-const { ALLOWED_YEARS } = require('../config/vars.config')
+const { ALLOWED_YEARS, PROVINCE_IDS } = require('../config/vars.config')
 const { theme, insideContainer, horizontalPadding, visuallyHidden } = require('../styles')
 const Button = require('./Button')
 
@@ -164,19 +164,12 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
               <option value="" selected=${!provinceId && !federal}>Nationwide</option>
               <option value="federal" selected=${!provinceId && federal}>Federal</option>
               <option disabled>──────────</option>
-              <option value="AB" selected=${provinceId === 'AB'}>Alberta</option>
-              <option value="BC" selected=${provinceId === 'BC'}>British Columbia</option>
-              <option value="MB" selected=${provinceId === 'MB'}>Manitoba</option>
-              <option value="NB" selected=${provinceId === 'NB'}>New Brunswick</option>
-              <option value="NL" selected=${provinceId === 'NL'}>Newfoundland and Labrador</option>
-              <option value="NS" selected=${provinceId === 'NS'}>Nova Scotia</option>
-              <option value="NT" selected=${provinceId === 'NT'}>Northwest Territories</option>
-              <option value="NU" selected=${provinceId === 'NU'}>Nunavut</option>
-              <option value="ON" selected=${provinceId === 'ON'}>Ontario</option>
-              <option value="PE" selected=${provinceId === 'PE'}>Prince Edward Island</option>
-              <option value="QC" selected=${provinceId === 'QC'}>Quebec</option>
-              <option value="SK" selected=${provinceId === 'SK'}>Saskatchewan</option>
-              <option value="YT" selected=${provinceId === 'YT'}>Yukon</option>
+              ${PROVINCE_IDS.map(
+                (pid) =>
+                  html`<option value=${pid} selected=${provinceId === pid}
+                    >${getProvinceNameFromId(pid)}</option
+                  >`,
+              )}
             </select>
           </div>
 
@@ -190,13 +183,9 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
               data-action="year-select"
               data-label=${`year-select-${provinceIdOrFederal || 'canada'}`}
             >
-              ${ALLOWED_YEARS.map((allowedYear) => {
-                return html`
-                  <option value=${allowedYear} selected=${year === allowedYear}
-                    >${allowedYear}</option
-                  >
-                `
-              })}
+              ${ALLOWED_YEARS.map(
+                (y) => html` <option value=${y} selected=${year === y}>${y}</option> `,
+              )}
             </select>
           </div>
 

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -92,27 +92,68 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     }
   }
 
-  /*
   #region-select {
-    width: 9em;
-    margin-right: ${theme.space.xs};
+    width: var(--region-select-width);
   }
-  */
+
+  #region-select-width {
+    font-weight: 600;
+    position: absolute;
+    visibility: hidden;
+  }
 
   *[data-hidden] {
     display: none;
   }
 `
 
+const getProvinceNameFromId = (provinceId) => {
+  switch (provinceId) {
+    case 'AB':
+      return 'Alberta'
+    case 'BC':
+      return 'British Columbia'
+    case 'MB':
+      return 'Manitoba'
+    case 'NB':
+      return 'New Brunswick'
+    case 'NL':
+      return 'Newfoundland and Labrador'
+    case 'NS':
+      return 'Nova Scotia'
+    case 'NT':
+      return 'Northwest Territories'
+    case 'NU':
+      return 'Nunavut'
+    case 'ON':
+      return 'Ontario'
+    case 'PE':
+      return 'Prince Edward Island'
+    case 'QC':
+      return 'Quebec'
+    case 'SK':
+      return 'Saskatchewan'
+    case 'YT':
+      return 'Yukon'
+    default:
+      return
+  }
+}
+
 const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
   const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
+  let regionName = getProvinceNameFromId(provinceId)
+  regionName = regionName || (federal ? 'Federal' : 'Nationwide')
+
   return html`
     <div class=${provinceIdOrFederal ? styles(theme.color[provinceIdOrFederal]) : styles()}>
       <div>
         <form action="/provinces" method="post">
           <div>
-            <label for="region-select" class=${visuallyHidden}>View by region</label>
+            <div id="region-select-width" aria-hidden="true">${regionName}</div>
 
+            <label for="region-select" class=${visuallyHidden}>View by region</label>
+            <span aria-hidden="true">See</span>
             <select
               name="region"
               id="region-select"
@@ -121,7 +162,7 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
               data-label=${`region-select-${provinceIdOrFederal || 'canada'}`}
             >
               <option value="" selected=${!provinceId && !federal}>Nationwide</option>
-              <option value="federal" selected=${!provinceId && federal}>Federal holidays</option>
+              <option value="federal" selected=${!provinceId && federal}>Federal</option>
               <option disabled>──────────</option>
               <option value="AB" selected=${provinceId === 'AB'}>Alberta</option>
               <option value="BC" selected=${provinceId === 'BC'}>British Columbia</option>
@@ -129,9 +170,7 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
               <option value="NB" selected=${provinceId === 'NB'}>New Brunswick</option>
               <option value="NL" selected=${provinceId === 'NL'}>Newfoundland and Labrador</option>
               <option value="NS" selected=${provinceId === 'NS'}>Nova Scotia</option>
-              <option value="NT" selected=${provinceId === 'NT'}
-                >Northwest <span class=${visuallyHidden}>Territories</span></option
-              >
+              <option value="NT" selected=${provinceId === 'NT'}>Northwest Territories</option>
               <option value="NU" selected=${provinceId === 'NU'}>Nunavut</option>
               <option value="ON" selected=${provinceId === 'ON'}>Ontario</option>
               <option value="PE" selected=${provinceId === 'PE'}>Prince Edward Island</option>
@@ -144,7 +183,6 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
           <div>
             <label for="year-select" class=${visuallyHidden}>View by year</label>
             <span aria-hidden="true">holidays for</span>
-
             <select
               name="year"
               id="year-select"

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -1,5 +1,6 @@
 const { html, getProvinceIdOrFederalString } = require('../utils')
 const { css } = require('emotion')
+const { ALLOWED_YEARS } = require('../config/vars.config')
 const { theme, insideContainer, horizontalPadding, visuallyHidden } = require('../styles')
 const Button = require('./Button')
 
@@ -151,9 +152,13 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
               data-action="year-select"
               data-label=${`year-select-${provinceIdOrFederal || 'canada'}`}
             >
-              <option value="2019" selected=${year === 2019}>2019</option>
-              <option value="2020" selected=${year === 2020}>2020</option>
-              <option value="2021" selected=${year === 2021}>2021</option>
+              ${ALLOWED_YEARS.map((allowedYear) => {
+                return html`
+                  <option value=${allowedYear} selected=${year === allowedYear}
+                    >${allowedYear}</option
+                  >
+                `
+              })}
             </select>
           </div>
 

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -143,7 +143,7 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
 
           <div>
             <label for="year-select" class=${visuallyHidden}>View by year</label>
-            <span>holidays for</span>
+            <span aria-hidden="true">holidays for</span>
 
             <select
               name="year"

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -24,6 +24,13 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     display: inline-block;
     margin-right: ${theme.space.xs};
     margin-bottom: ${theme.space.xs};
+
+    &:last-of-type{
+      display: block;
+      @media (${theme.mq.md}) {
+        display: inline-block;
+      }
+    }
   }
 
   form span {

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -20,15 +20,16 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     ${insideContainer};
   }
 
-  label {
-    display: block;
+  form > div {
+    display: inline-block;
     margin-right: ${theme.space.xs};
-    font-weight: 600;
-    margin-bottom: ${theme.space.xxs};
+    margin-bottom: ${theme.space.xs};
+  }
 
-    @media (${theme.mq.md}) {
-      display: inline-block;
-    }
+  form span {
+    font-weight: 500;
+    display: inline-block;
+    margin-right: ${theme.space.xs};
   }
 
   select {
@@ -83,51 +84,81 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     }
   }
 
+  /*
+  #region-select {
+    width: 9em;
+    margin-right: ${theme.space.xs};
+  }
+  */
+
   *[data-hidden] {
     display: none;
   }
 `
 
-const ProvincePicker = ({ provinceId, federal }) => {
+const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
   const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
   return html`
     <div class=${provinceIdOrFederal ? styles(theme.color[provinceIdOrFederal]) : styles()}>
       <div>
         <form action="/provinces" method="post">
-          <label for="region-select">View by region</label>
+          <div>
+            <label for="region-select" class=${visuallyHidden}>View by region</label>
 
-          <select
-            name="region"
-            id="region-select"
-            data-event="true"
-            data-action="region-select"
-            data-label=${`region-select-${provinceIdOrFederal || 'canada'}`}
-          >
-            <option value="" selected=${!provinceId && !federal}>Nationwide</option>
-            <option value="federal" selected=${!provinceId && federal}>Federal holidays</option>
-            <option disabled>──────────</option>
-            <option value="AB" selected=${provinceId === 'AB'}>Alberta</option>
-            <option value="BC" selected=${provinceId === 'BC'}>British Columbia</option>
-            <option value="MB" selected=${provinceId === 'MB'}>Manitoba</option>
-            <option value="NB" selected=${provinceId === 'NB'}>New Brunswick</option>
-            <option value="NL" selected=${provinceId === 'NL'}>Newfoundland and Labrador</option>
-            <option value="NS" selected=${provinceId === 'NS'}>Nova Scotia</option>
-            <option value="NT" selected=${provinceId === 'NT'}>Northwest Territories</option>
-            <option value="NU" selected=${provinceId === 'NU'}>Nunavut</option>
-            <option value="ON" selected=${provinceId === 'ON'}>Ontario</option>
-            <option value="PE" selected=${provinceId === 'PE'}>Prince Edward Island</option>
-            <option value="QC" selected=${provinceId === 'QC'}>Quebec</option>
-            <option value="SK" selected=${provinceId === 'SK'}>Saskatchewan</option>
-            <option value="YT" selected=${provinceId === 'YT'}>Yukon</option>
-          </select>
+            <select
+              name="region"
+              id="region-select"
+              data-event="true"
+              data-action="region-select"
+              data-label=${`region-select-${provinceIdOrFederal || 'canada'}`}
+            >
+              <option value="" selected=${!provinceId && !federal}>Nationwide</option>
+              <option value="federal" selected=${!provinceId && federal}>Federal holidays</option>
+              <option disabled>──────────</option>
+              <option value="AB" selected=${provinceId === 'AB'}>Alberta</option>
+              <option value="BC" selected=${provinceId === 'BC'}>British Columbia</option>
+              <option value="MB" selected=${provinceId === 'MB'}>Manitoba</option>
+              <option value="NB" selected=${provinceId === 'NB'}>New Brunswick</option>
+              <option value="NL" selected=${provinceId === 'NL'}>Newfoundland and Labrador</option>
+              <option value="NS" selected=${provinceId === 'NS'}>Nova Scotia</option>
+              <option value="NT" selected=${provinceId === 'NT'}
+                >Northwest <span class=${visuallyHidden}>Territories</span></option
+              >
+              <option value="NU" selected=${provinceId === 'NU'}>Nunavut</option>
+              <option value="ON" selected=${provinceId === 'ON'}>Ontario</option>
+              <option value="PE" selected=${provinceId === 'PE'}>Prince Edward Island</option>
+              <option value="QC" selected=${provinceId === 'QC'}>Quebec</option>
+              <option value="SK" selected=${provinceId === 'SK'}>Saskatchewan</option>
+              <option value="YT" selected=${provinceId === 'YT'}>Yukon</option>
+            </select>
+          </div>
 
-          <${Button}
-            type="submit"
-            id="region-select__button"
-            style="padding: 6.5px 9px 3.5px 9px; margin-left: 10px;"
-            color="${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}"
-            ><span class=${visuallyHidden}>Submit</span>→<//
-          >
+          <div>
+            <label for="year-select" class=${visuallyHidden}>View by year</label>
+            <span>holidays for</span>
+
+            <select
+              name="year"
+              id="year-select"
+              data-event="true"
+              data-action="year-select"
+              data-label=${`year-select-${provinceIdOrFederal || 'canada'}`}
+            >
+              <option value="2019" selected=${year === 2019}>2019</option>
+              <option value="2020" selected=${year === 2020}>2020</option>
+              <option value="2021" selected=${year === 2021}>2021</option>
+            </select>
+          </div>
+
+          <div>
+            <${Button}
+              type="submit"
+              id="region-select__button"
+              style="padding: 6.5px 9px 3.5px 9px; font-weight: 500;"
+              color="${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}"
+              ><span class="">Submit</span> →<//
+            >
+          </div>
         </form>
       </div>
       <script src="/js/picker.js"></script>

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -36,3 +36,21 @@ test('Button displays properly as a link', () => {
   expect($('a').attr('href')).toEqual('/download')
   expect($('a').text()).toEqual('Click me')
 })
+
+test('Button displays with className as a link', () => {
+  expect(1).toBe(1)
+  const $ = cheerio.load(
+    render(
+      html`
+        <${Button} id="link-button" className="ghost" href="/download">Click me</button>
+      `,
+    ),
+  )
+
+  expect($('button').length).toBe(0)
+  expect($('a').length).toBe(1)
+  expect($('a').attr('id')).toEqual('link-button')
+  expect($('a').attr('href')).toEqual('/download')
+  expect($('a').attr('class')).toMatch(/^ghost/)
+  expect($('a').text()).toEqual('Click me')
+})

--- a/src/components/__tests__/ProvincePicker.test.js
+++ b/src/components/__tests__/ProvincePicker.test.js
@@ -5,59 +5,56 @@ const { html } = require('../../utils')
 const ProvincePicker = require('../ProvincePicker.js')
 
 const renderProvincePicker = ({ provinceId, federal } = {}) => {
-  return cheerio.load(
-    render(
-      html`
-        <${ProvincePicker} ...${{ provinceId, federal }}//>
-      `,
-    ),
-  )
+  return cheerio.load(render(html` <${ProvincePicker} ...${{ provinceId, federal }}//> `))
 }
 
 describe('<ProvincePicker>', () => {
   test(' renders properly', () => {
     const $ = renderProvincePicker()
-    expect($('label').text()).toEqual('View by region')
-    expect($('select').length).toBe(1)
-    expect($('select option').length).toBe(16)
+    expect($('label').text()).toEqual('View by regionView by year')
+    expect($('select').length).toBe(2)
+    expect($('select option').length).toBe(19)
     expect($('select option').text()).toEqual(
-      'NationwideFederal holidays──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon',
+      'NationwideFederal holidays──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon201920202021',
     )
   })
 
-  test('renders selected option as "Nationwide" be default', () => {
-    const $ = renderProvincePicker()
-    expect($('select').length).toBe(1)
-    expect($('select option[selected]').text()).toEqual('Nationwide')
+  describe('province select', () => {
+    test('renders selected option as "Nationwide" be default', () => {
+      const $ = renderProvincePicker()
+      expect($('select').eq(0).find('option[selected]').text()).toEqual('Nationwide')
+    })
+
+    test('renders selected option with matching provinceId', () => {
+      const $ = renderProvincePicker({ provinceId: 'AB' })
+      expect($('select').eq(0).find('option[selected]').text()).toEqual('Alberta')
+    })
+
+    test('renders no selected option with bad provinceId', () => {
+      const $ = renderProvincePicker({ provinceId: 'HAWAII' })
+      expect($('select').eq(0).find('option[selected]').length).toBe(0)
+    })
+
+    test('renders selected option as "Federal holidays" if "federal" is true', () => {
+      const $ = renderProvincePicker({ federal: true })
+      expect($('select').eq(0).find('option[selected]').text()).toEqual('Federal holidays')
+    })
+
+    test('renders province option if a provinceId AND a federal option are passed in', () => {
+      const $ = renderProvincePicker({ provinceId: 'PE', federal: true })
+      expect($('select').eq(0).find('option[selected]').text()).toEqual('Prince Edward Island')
+    })
+
+    test('renders no selected option by default if a BAD provinceId AND a federal option are passed in', () => {
+      const $ = renderProvincePicker({ provinceId: 'TEXAS', federal: true })
+      expect($('select').eq(0).find('option[selected]').length).toBe(0)
+    })
   })
 
-  test('renders selected option with matching provinceId', () => {
-    const $ = renderProvincePicker({ provinceId: 'AB' })
-    expect($('select').length).toBe(1)
-    expect($('select option[selected]').text()).toEqual('Alberta')
-  })
-
-  test('renders no selected option with bad provinceId', () => {
-    const $ = renderProvincePicker({ provinceId: 'HAWAII' })
-    expect($('select').length).toBe(1)
-    expect($('select option[selected]').length).toBe(0)
-  })
-
-  test('renders selected option as "Federal holidays" if "federal" is true', () => {
-    const $ = renderProvincePicker({ federal: true })
-    expect($('select').length).toBe(1)
-    expect($('select option[selected]').text()).toEqual('Federal holidays')
-  })
-
-  test('renders province option if a provinceId AND a federal option are passed in', () => {
-    const $ = renderProvincePicker({ provinceId: 'PE', federal: true })
-    expect($('select').length).toBe(1)
-    expect($('select option[selected]').text()).toEqual('Prince Edward Island')
-  })
-
-  test('renders no selected option by default if a BAD provinceId AND a federal option are passed in', () => {
-    const $ = renderProvincePicker({ provinceId: 'TEXAS', federal: true })
-    expect($('select').length).toBe(1)
-    expect($('select option[selected]').length).toBe(0)
+  describe('year select', () => {
+    test('renders selected option as "2020" be default', () => {
+      const $ = renderProvincePicker()
+      expect($('select').eq(1).find('option[selected]').text()).toEqual('2020')
+    })
   })
 })

--- a/src/components/__tests__/ProvincePicker.test.js
+++ b/src/components/__tests__/ProvincePicker.test.js
@@ -16,7 +16,7 @@ describe('<ProvincePicker>', () => {
     expect($('select').length).toBe(2)
     expect($('select option').length).toBe(19)
     expect($('select option').text()).toEqual(
-      'NationwideFederal holidays──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon201920202021',
+      'NationwideFederal──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon201920202021',
     )
   })
 
@@ -36,9 +36,9 @@ describe('<ProvincePicker>', () => {
       expect($('select').eq(0).find('option[selected]').length).toBe(0)
     })
 
-    test('renders selected region as "Federal holidays" if "federal" is true', () => {
+    test('renders selected region as "Federal" if "federal" is true', () => {
       const $ = renderProvincePicker({ federal: true })
-      expect($('select').eq(0).find('option[selected]').text()).toEqual('Federal holidays')
+      expect($('select').eq(0).find('option[selected]').text()).toEqual('Federal')
     })
 
     test('renders province region if a provinceId AND a federal option are passed in', () => {

--- a/src/components/__tests__/ProvincePicker.test.js
+++ b/src/components/__tests__/ProvincePicker.test.js
@@ -14,9 +14,11 @@ describe('<ProvincePicker>', () => {
     const $ = renderProvincePicker()
     expect($('label').text()).toEqual('View by regionView by year')
     expect($('select').length).toBe(2)
-    expect($('select option').length).toBe(19)
+    expect($('select option').length).toBe(21)
     expect($('select option').text()).toEqual(
-      'NationwideFederal──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon201920202021',
+      `NationwideFederal──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon${ALLOWED_YEARS.join(
+        '',
+      )}`,
     )
   })
 

--- a/src/components/__tests__/ProvincePicker.test.js
+++ b/src/components/__tests__/ProvincePicker.test.js
@@ -1,11 +1,12 @@
 const render = require('preact-render-to-string')
 const cheerio = require('cheerio')
 const { html } = require('../../utils')
+const { ALLOWED_YEARS } = require('../../config/vars.config')
 
 const ProvincePicker = require('../ProvincePicker.js')
 
-const renderProvincePicker = ({ provinceId, federal } = {}) => {
-  return cheerio.load(render(html` <${ProvincePicker} ...${{ provinceId, federal }}//> `))
+const renderProvincePicker = ({ provinceId, federal, year } = {}) => {
+  return cheerio.load(render(html` <${ProvincePicker} ...${{ provinceId, federal, year }}//> `))
 }
 
 describe('<ProvincePicker>', () => {
@@ -20,41 +21,53 @@ describe('<ProvincePicker>', () => {
   })
 
   describe('province select', () => {
-    test('renders selected option as "Nationwide" be default', () => {
+    test('renders selected region as "Nationwide" be default', () => {
       const $ = renderProvincePicker()
       expect($('select').eq(0).find('option[selected]').text()).toEqual('Nationwide')
     })
 
-    test('renders selected option with matching provinceId', () => {
+    test('renders selected region with matching provinceId', () => {
       const $ = renderProvincePicker({ provinceId: 'AB' })
       expect($('select').eq(0).find('option[selected]').text()).toEqual('Alberta')
     })
 
-    test('renders no selected option with bad provinceId', () => {
+    test('renders no selected region with bad provinceId', () => {
       const $ = renderProvincePicker({ provinceId: 'HAWAII' })
       expect($('select').eq(0).find('option[selected]').length).toBe(0)
     })
 
-    test('renders selected option as "Federal holidays" if "federal" is true', () => {
+    test('renders selected region as "Federal holidays" if "federal" is true', () => {
       const $ = renderProvincePicker({ federal: true })
       expect($('select').eq(0).find('option[selected]').text()).toEqual('Federal holidays')
     })
 
-    test('renders province option if a provinceId AND a federal option are passed in', () => {
+    test('renders province region if a provinceId AND a federal option are passed in', () => {
       const $ = renderProvincePicker({ provinceId: 'PE', federal: true })
       expect($('select').eq(0).find('option[selected]').text()).toEqual('Prince Edward Island')
     })
 
-    test('renders no selected option by default if a BAD provinceId AND a federal option are passed in', () => {
+    test('renders no selected region by default if a BAD provinceId AND a federal option are passed in', () => {
       const $ = renderProvincePicker({ provinceId: 'TEXAS', federal: true })
       expect($('select').eq(0).find('option[selected]').length).toBe(0)
     })
   })
 
   describe('year select', () => {
-    test('renders selected option as "2020" be default', () => {
+    test('renders selected year as "2020" by default', () => {
       const $ = renderProvincePicker()
       expect($('select').eq(1).find('option[selected]').text()).toEqual('2020')
+    })
+
+    ALLOWED_YEARS.map((year) => {
+      test(`renders selected year as ${year} when passed in`, () => {
+        const $ = renderProvincePicker({ year })
+        expect($('select').eq(1).find('option[selected]').text()).toEqual(`${year}`)
+      })
+    })
+
+    test('renders no selected year when a bad year is passed', () => {
+      const $ = renderProvincePicker({ year: '1999' })
+      expect($('select').eq(1).find('option[selected]').length).toBe(0)
     })
   })
 })

--- a/src/config/vars.config.js
+++ b/src/config/vars.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   ALLOWED_YEARS: [2019, 2020, 2021],
+  PROVINCE_IDS: ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'],
 }

--- a/src/config/vars.config.js
+++ b/src/config/vars.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  ALLOWED_YEARS: [2019, 2020, 2021],
+  ALLOWED_YEARS: [2018, 2019, 2020, 2021, 2022],
   PROVINCE_IDS: ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'],
 }

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -6,7 +6,7 @@ const Feedback = () =>
   html`
     <${Layout} route="/api">
       <${Content}>
-        <h1>Holidays API</h1>
+        <h1>Canada Holidays API</h1>
         <p>
           <a href="/">canada-holidays.ca</a> is powered by a JSON API that returns Canada’s
           statutory holidays, and you can use it too.${' '}

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -154,7 +154,7 @@ const Province = ({
       <div class=${provinceIdOrFederal ? styles(theme.color[provinceIdOrFederal]) : styles()}>
         <section id="next-holiday">
           <${NextHolidayBox} ...${{ nextHoliday, provinceName, provinceId, federal, year }} />
-          <${ProvincePicker} ...${{ provinceId, federal }}=/>
+          <${ProvincePicker} ...${{ provinceId, federal, year }}=/>
         </section>
 
         <section class=${horizontalPadding}>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -176,7 +176,7 @@ const Province = ({
                       ? `canada-holidays-${provinceIdOrFederal}-${year}.ics`
                       : `canada-holidays-${year}.ics`}
                     color=${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}
-                    ghost=${true}
+                    className=${'ghost'}
                     data-event="true"
                     data-action="download-holidays"
                     data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}`}

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -31,6 +31,10 @@ const document = ({ title, content, docProps: { meta, path } }) => {
         <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32" />
         <link href="https://fonts.googleapis.com/css?family=Gothic+A1:300,400,500,600,700&display=swap" rel="stylesheet" />
         <style>
+          :root {
+            --region-select-width: auto;
+          }
+
           * {
             box-sizing: border-box;
           }
@@ -94,11 +98,7 @@ const document = ({ title, content, docProps: { meta, path } }) => {
 const renderPage = ({ pageComponent, title = '', props, docProps }) => {
   const Page = require(`./${pageComponent}.js`)
 
-  const content = render(
-    html`
-      <${Page} ...${props} />
-    `,
-  )
+  const content = render(html` <${Page} ...${props} /> `)
 
   // if title is not explicitly passed in, use the name of the page component
   title = title || pageComponent

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -2,8 +2,9 @@ const request = require('supertest')
 const db = require('sqlite')
 const Promise = require('bluebird')
 const app = require('../../server.js')
-const { getCurrentHolidayYear } = require('../../utils')
 const cheerio = require('cheerio')
+const { ALLOWED_YEARS } = require('../../config/vars.config')
+const { getCurrentHolidayYear } = require('../../utils')
 
 describe('Test /api responses', () => {
   beforeAll(async () => {
@@ -209,8 +210,7 @@ describe('Test /api responses', () => {
     })
 
     describe('with ?years=', () => {
-      let years = ['2019', '2020', '2021']
-      years.map((year) => {
+      ALLOWED_YEARS.map((year) => {
         test(`${year} it should return all holidays for ${year}`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
           expect(response.statusCode).toBe(200)
@@ -218,12 +218,12 @@ describe('Test /api responses', () => {
           let { holidays } = JSON.parse(response.text)
 
           holidays.map((holiday) => {
-            expect(holiday.date.slice(0, 4)).toEqual(year)
+            expect(holiday.date.slice(0, 4)).toEqual(`${year}`)
           })
         })
       })
 
-      let badYears = ['2018', '2022', '1', null, undefined, false, 'orange', 'christmas']
+      let badYears = ['2017', '2023', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map((year) => {
         test(`${year} it should return all holidays for ${getCurrentHolidayYear()} with the current year`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
@@ -270,19 +270,18 @@ describe('Test /api responses', () => {
     })
 
     describe('with ?years=', () => {
-      let years = ['2019', '2020', '2021']
-      years.map((year) => {
+      ALLOWED_YEARS.map((year) => {
         test(`${year} it should a holiday with the right dateString`, async () => {
           const response = await request(app).get(`/api/v1/holidays/16?year=${year}`)
           expect(response.statusCode).toBe(200)
 
           let { holiday } = JSON.parse(response.text)
 
-          expect(holiday.date.slice(0, 4)).toEqual(year)
+          expect(holiday.date.slice(0, 4)).toEqual(`${year}`)
         })
       })
 
-      let badYears = ['2018', '2022', '1', null, undefined, false, 'orange', 'christmas']
+      let badYears = ['2017', '2023', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map((year) => {
         test(`${year} it should a holiday with the current year`, async () => {
           const response = await request(app).get(`/api/v1/holidays/16?year=${year}`)

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -59,8 +59,8 @@ describe('Test /api responses', () => {
     test('it should return the h1, title, and meta tag', async () => {
       const response = await request(app).get('/api')
       const $ = cheerio.load(response.text)
-      expect($('h1').text()).toEqual('Holidays API')
-      expect($('title').text()).toEqual('Holidays API — Canada statutory holidays')
+      expect($('h1').text()).toEqual('Canada Holidays API')
+      expect($('title').text()).toEqual('Canada Holidays API — Canada Holidays')
       expect($('meta[name="description"]').attr('content')).toEqual(
         'A free JSON API for Canada’s statutory holidays. Return all holidays or filter by a specific region.',
       )

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -128,7 +128,7 @@ describe('Test ui responses', () => {
           })
         })
 
-        const BAD_YEARS = ['2017', '2018', '2022', '2023', '1', 'false', 'diplodocus']
+        const BAD_YEARS = ['2016', '2017', '2023', '2024', '1', 'false', 'diplodocus']
         BAD_YEARS.map((badYear) => {
           test(`it should return no year path for an invalid year: "${badYear}`, async () => {
             const response = await request(app).post('/provinces').send({ badYear })
@@ -139,9 +139,9 @@ describe('Test ui responses', () => {
 
         describe('for param "region" AND param "year"', () => {
           const params = [
-            { region: 'AB', year: '2018', url: '/province/AB' },
-            { region: 'federal', year: '2018', url: '/federal' },
-            { region: '', year: '2018', url: '/' },
+            { region: 'AB', year: '1000', url: '/province/AB' },
+            { region: 'federal', year: '1000', url: '/federal' },
+            { region: '', year: '1000', url: '/' },
             { region: 'AB', year: '2021', url: '/province/AB/2021' },
             { region: 'federal', year: '2021', url: '/federal/2021' },
             { region: '', year: '2021', url: '/2021' },
@@ -285,7 +285,7 @@ describe('Test ui responses', () => {
             })
           })
 
-          const INVALID_YEARS = [2017, 2018, 2022, 2023]
+          const INVALID_YEARS = [2016, 2017, 2023, 2024]
           INVALID_YEARS.map((invalidYear) => {
             test(`it should return 400 for url: "${url}" and year: "${invalidYear}"`, async () => {
               const response = await request(app).get(`${url}/${invalidYear}`)
@@ -295,7 +295,7 @@ describe('Test ui responses', () => {
         })
 
         describe('with "year" query params', () => {
-          const INVALID_YEARS = [-1, 0, 1, 2018, 2022, 'pterodactyl']
+          const INVALID_YEARS = [-1, 0, 1, 2017, 2023, 'pterodactyl']
           INVALID_YEARS.map((invalidYear) => {
             test(`it should return 200 for url: "${url}" and a bad query param: "${invalidYear}"`, async () => {
               const response = await request(app).get(`${url}?year=${invalidYear}`)

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -67,7 +67,7 @@ describe('Test ui responses', () => {
         const response = await request(app).get('/provinces')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('All regions in Canada')
-        expect($('title').text()).toEqual('All regions in Canada — Canada statutory holidays')
+        expect($('title').text()).toEqual('All regions in Canada — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Upcoming stat holidays for all regions in Canada. See all federal statutory holidays in Canada in 2020.',
         )
@@ -159,26 +159,6 @@ describe('Test ui responses', () => {
             })
           })
         })
-
-        /*
-        const params = [
-          { region: 'AB', url: '/province/AB' },
-          { region: 'ab', url: '/province/AB' },
-          { region: 'Alberta', url: '/province/AL' },
-          { region: 'a', url: '/province/A' },
-          { region: '<script>', url: '/province/%3CS' },
-          { region: 'https://evil.org', url: '/province/HT' },
-          { region: 'false', url: '/province/FA' },
-          { region: '1', url: '/province/1' },
-        ]
-        params.map((p) => {
-          test(`it should return 302 to ${p.url} uppercased for param: '${p.region}'`, async () => {
-            const response = await request(app).post('/provinces').send({ region: p.region })
-            expect(response.statusCode).toBe(302)
-            expect(response.headers.location).toBe(p.url)
-          })
-        })
-        */
       })
     })
   })
@@ -194,7 +174,9 @@ describe('Test ui responses', () => {
         const response = await request(app).get('/province/MB')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toMatch(/^Manitoba’s next statutory holiday is/)
-        expect($('title').text()).toEqual('Manitoba (MB) statutory holidays in 2020')
+        expect($('title').text()).toEqual(
+          'Manitoba (MB) statutory holidays in 2020 — Canada Holidays',
+        )
         expect($('meta[name="description"]').attr('content')).toMatch(/^MB’s next stat holiday is/)
         expect($('meta[name="description"]').attr('content')).toMatch(
           /See all statutory holidays in Manitoba, Canada in 2020/,
@@ -207,7 +189,9 @@ describe('Test ui responses', () => {
         const response = await request(app).get('/province/MB/2021')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Manitobastatutory Holidays in 2021')
-        expect($('title').text()).toEqual('Manitoba (MB) statutory holidays in 2021')
+        expect($('title').text()).toEqual(
+          'Manitoba (MB) statutory holidays in 2021 — Canada Holidays',
+        )
         expect($('meta[name="description"]').attr('content')).toEqual(
           'See all statutory holidays in Manitoba, Canada in 2021.',
         )
@@ -271,7 +255,7 @@ describe('Test ui responses', () => {
                 ', ',
               )}].`,
             )
-            expect($('title').text()).toEqual('Error: 400 — Canada statutory holidays')
+            expect($('title').text()).toEqual('Error: 400 — Canada Holidays')
             expect($('meta[name="description"]').attr('content')).toEqual(
               'Error: No holidays for the year “1000”',
             )
@@ -337,7 +321,7 @@ describe('Test ui responses', () => {
         const response = await request(app).get('/about')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('About')
-        expect($('title').text()).toEqual('About — Canada statutory holidays')
+        expect($('title').text()).toEqual('About — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Check my sources, use the API, get in touch, etc.',
         )
@@ -354,7 +338,7 @@ describe('Test ui responses', () => {
         const response = await request(app).get('/feedback')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Feedback')
-        expect($('title').text()).toEqual('Feedback — Canada statutory holidays')
+        expect($('title').text()).toEqual('Feedback — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Reprt a problem, tell me I’m cool, or let’s just chat even.',
         )
@@ -372,7 +356,7 @@ describe('Test ui responses', () => {
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Add Canada’s 2020 holidays to your calendar')
         expect($('title').text()).toEqual(
-          'Add Canada’s 2020 holidays to your calendar — Canada statutory holidays',
+          'Add Canada’s 2020 holidays to your calendar — Canada Holidays',
         )
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Download Canadian holidays and import them to your Outlook, iCal, or Google Calendar. Add all Canadian statutory holidays or just for your region.',
@@ -390,9 +374,7 @@ describe('Test ui responses', () => {
         const response = await request(app).get('/do-federal-holidays-apply-to-me')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Do federal holidays apply to me?')
-        expect($('title').text()).toEqual(
-          'Do federal holidays apply to me? — Canada statutory holidays',
-        )
+        expect($('title').text()).toEqual('Do federal holidays apply to me? — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'How to tell if you get federal holidays or provincial holidays in Canada.',
         )
@@ -420,7 +402,7 @@ describe('Test ui responses', () => {
           expect($('p').text()).toEqual(
             'Error: No province with id “pangea”. Accepted province IDs are: [AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT].',
           )
-          expect($('title').text()).toEqual('Error: 400 — Canada statutory holidays')
+          expect($('title').text()).toEqual('Error: 400 — Canada Holidays')
           expect($('meta[name="description"]').attr('content')).toEqual(
             'Error: No province with id “pangea”',
           )
@@ -433,7 +415,7 @@ describe('Test ui responses', () => {
         expect($('p').text()).toEqual(
           'Error: No province with id “pangea”. Accepted province IDs are: [AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT].',
         )
-        expect($('title').text()).toEqual('Error: 400 — Canada statutory holidays')
+        expect($('title').text()).toEqual('Error: 400 — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Error: No province with id “pangea”',
         )
@@ -451,7 +433,7 @@ describe('Test ui responses', () => {
       const response = await request(app).get('/allosaurus')
       const $ = cheerio.load(response.text)
       expect($('h1').text()).toEqual('404')
-      expect($('title').text()).toEqual('Error: 404 — Canada statutory holidays')
+      expect($('title').text()).toEqual('Error: 404 — Canada Holidays')
       expect($('meta[name="description"]').attr('content')).toEqual('Oopsie daisy')
     })
   })

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -56,7 +56,7 @@ router.get('/', (req, res) => {
   return res.send(
     renderPage({
       pageComponent: 'API',
-      title: 'Holidays API — Canada statutory holidays',
+      title: 'Canada Holidays API — Canada Holidays',
       docProps: {
         meta:
           'A free JSON API for Canada’s statutory holidays. Return all holidays or filter by a specific region.',
@@ -72,7 +72,7 @@ router.get('*', (req, res) => {
 })
 
 // eslint-disable-next-line no-unused-vars
-router.use(function(err, req, res, next) {
+router.use(function (err, req, res, next) {
   return res.send({
     error: {
       status: res.statusCode,

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -178,6 +178,8 @@ router.get('/provinces', dbmw(db, getProvinces), (req, res) => {
 router.post('/provinces', (req, res) => {
   let url = '/'
   const region = req.body.region || ''
+  const year = parseInt(req.body.year)
+  const GOOD_YEARS = ALLOWED_YEARS.filter((y) => y !== getCurrentHolidayYear())
 
   switch (region) {
     case '':
@@ -187,6 +189,11 @@ router.post('/provinces', (req, res) => {
       break
     default:
       url = `/province/${encodeURIComponent(region.substring(0, 2).toUpperCase())}`
+  }
+
+  // if year is a truthy value and is whitelisted, add it to the path
+  if (year && GOOD_YEARS.includes(year)) {
+    url = url.endsWith('/') ? `${url}${year}` : `${url}/${year}`
   }
 
   return res.redirect(url)

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -77,7 +77,7 @@ router.get(
     return res.send(
       renderPage({
         pageComponent: 'Province',
-        title: `${provinceName} (${provinceId}) statutory holidays in ${year}`,
+        title: `${provinceName} (${provinceId}) statutory holidays in ${year} — Canada Holidays`,
         docProps: { meta, path: req.path },
         props: {
           data: { holidays, nextHoliday, provinceName, provinceId, year },
@@ -103,7 +103,7 @@ router.get(
     return res.send(
       renderPage({
         pageComponent: 'Province',
-        title: `${provinceName} (${provinceId}) statutory holidays in ${year}`,
+        title: `${provinceName} (${provinceId}) statutory holidays in ${year} — Canada Holidays`,
         docProps: { meta, path: req.path },
         props: {
           data: {
@@ -165,7 +165,7 @@ router.get('/provinces', dbmw(db, getProvinces), (req, res) => {
   return res.send(
     renderPage({
       pageComponent: 'Provinces',
-      title: 'All regions in Canada — Canada statutory holidays',
+      title: 'All regions in Canada — Canada Holidays',
       docProps: {
         meta: `Upcoming stat holidays for all regions in Canada. See all federal statutory holidays in Canada in ${getCurrentHolidayYear()}.`,
         path: req.path,
@@ -205,7 +205,7 @@ router.get('/do-federal-holidays-apply-to-me', (req, res) => {
   return res.send(
     renderPage({
       pageComponent: 'FederallyRegulated',
-      title: 'Do federal holidays apply to me? — Canada statutory holidays',
+      title: 'Do federal holidays apply to me? — Canada Holidays',
       docProps: {
         meta: 'How to tell if you get federal holidays or provincial holidays in Canada.',
         path: req.path,
@@ -220,7 +220,7 @@ router.get('/about', dbmw(db, getHolidaysWithProvinces), (req, res) => {
   return res.send(
     renderPage({
       pageComponent: 'About',
-      title: 'About — Canada statutory holidays',
+      title: 'About — Canada Holidays',
       docProps: {
         meta: 'Check my sources, use the API, get in touch, etc.',
         path: req.path,
@@ -234,7 +234,7 @@ router.get('/feedback', (req, res) => {
   return res.send(
     renderPage({
       pageComponent: 'Feedback',
-      title: 'Feedback — Canada statutory holidays',
+      title: 'Feedback — Canada Holidays',
       docProps: {
         meta: 'Reprt a problem, tell me I’m cool, or let’s just chat even.',
         path: req.path,
@@ -248,7 +248,7 @@ router.get('/add-holidays-to-calendar', dbmw(db, getProvinces), (req, res) => {
   return res.send(
     renderPage({
       pageComponent: 'AddHolidays',
-      title: 'Add Canada’s 2020 holidays to your calendar — Canada statutory holidays',
+      title: 'Add Canada’s 2020 holidays to your calendar — Canada Holidays',
       docProps: {
         meta:
           'Download Canadian holidays and import them to your Outlook, iCal, or Google Calendar. Add all Canadian statutory holidays or just for your region.',
@@ -269,7 +269,7 @@ router.use(function (err, req, res, next) {
   return res.send(
     renderPage({
       pageComponent: 'Error',
-      title: `Error: ${res.statusCode} — Canada statutory holidays`,
+      title: `Error: ${res.statusCode} — Canada Holidays`,
       docProps: { meta: err.message.split('.')[0], path: req.path },
       props: {
         data: {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,7 +2,7 @@ const { h } = require('preact')
 const htm = require('htm')
 const validator = require('validator')
 const createError = require('http-errors')
-const { ALLOWED_YEARS } = require('../config/vars.config')
+const { ALLOWED_YEARS, PROVINCE_IDS } = require('../config/vars.config')
 
 const html = htm.bind(h)
 
@@ -55,9 +55,7 @@ const dbmw = (db, cb) => {
 
 // returns true if province ID exists else false. Case insensitive.
 const isProvinceId = (provinceId) => {
-  return ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'].includes(
-    provinceId.toUpperCase(),
-  )
+  return PROVINCE_IDS.includes(provinceId.toUpperCase())
 }
 
 // middleware for returning "bad year" errors
@@ -69,7 +67,9 @@ const checkYearErr = (req, res, next) => {
     next(
       createError(
         400,
-        `Error: No holidays for the year “${year}”. Accepted years are: [2019, 2020, 2021].`,
+        `Error: No holidays for the year “${year}”. Accepted years are: [${ALLOWED_YEARS.join(
+          ', ',
+        )}].`,
       ),
     )
   }
@@ -86,7 +86,9 @@ const checkProvinceIdErr = (req, res, next) => {
     next(
       createError(
         400,
-        `Error: No province with id “${provinceId}”. Accepted province IDs are: [AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT].`,
+        `Error: No province with id “${provinceId}”. Accepted province IDs are: [${PROVINCE_IDS.join(
+          ', ',
+        )}].`,
       ),
     )
   }


### PR DESCRIPTION
This PR does a bunch of things, but mainly adds a "year picker" to the frontend which looks a lot like the region picker.

It also adds in the years `2018` and `2022`. So now, you can see the current year, plus or minus 2 years.

And finally, there are a couple of very small updates. 

1. Call it "Canada Holidays API" because that's what it is
2. Say `— Canada Holidays` after page titles because that's what the header says

## Gif 

This is the most interesting thing to show: it's the new year picker.

![picker](https://user-images.githubusercontent.com/2454380/80065026-6a207a00-8507-11ea-86c2-c5dca30f85c4.gif)
