### PR TITLE
Add "download holidays" link to "years" pages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 - add holidays by year to the frontend
   - Add years to dates on years pages?
   - add new pages to sitemap
-- put "download" button/link onto other year pages
 - make API to return CSV format
   - page for CSV downloads
 - swagger api docs?
@@ -14,6 +13,9 @@
 
 # DONE
 
+- bug: events on the same date should have different UIDs in .isc output
+- add years to ICS download paths as well
+- put "download" button/link onto other year pages
 - more specific name for the API
 - allowed province ids in global var
 - add picker for year

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 
 # DONE
 
+- margin at the bottom
 - bug: events on the same date should have different UIDs in .isc output
 - add years to ICS download paths as well
 - put "download" button/link onto other year pages

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 
 # DONE
 
-- margin at the bottom
+- remove shortcut ICS routes — all routes need years now
 - bug: events on the same date should have different UIDs in .isc output
 - add years to ICS download paths as well
 - put "download" button/link onto other year pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "1.11.0",
+  "version": "2.0.0",
   "description": "hols for cans: holidays api and holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/CalButton.js
+++ b/src/components/CalButton.js
@@ -1,0 +1,24 @@
+const { html, getProvinceIdOrFederalString } = require('../utils')
+const Button = require('../components/Button.js')
+const { theme } = require('../styles')
+
+const CalButton = ({ federal, provinceId, year = 2020, className = '' }) => {
+  const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
+
+  return html`
+    <${Button}
+      href=${`${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}/${year}`}
+      download=${provinceIdOrFederal
+        ? `canada-holidays-${provinceIdOrFederal}-${year}.ics`
+        : `canada-holidays-${year}.ics`}
+      color=${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}
+      className=${className}
+      data-event="true"
+      data-action="download-holidays"
+      data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}-${year}`}
+      >Add to your calendar<//
+    >
+  `
+}
+
+module.exports = CalButton

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -4,7 +4,7 @@ const { theme, insideContainer, horizontalPadding, visuallyHidden } = require('.
 const NextHoliday = require('./NextHoliday.js')
 const ObservingProvinces = require('./ObservingProvinces.js')
 const ProvinceTitle = require('./ProvinceTitle.js')
-const Button = require('../components/Button.js')
+const CalButton = require('../components/CalButton.js')
 const { relativeDate } = require('../dates')
 const { shade, randomInt } = require('../utils/so.js')
 
@@ -98,22 +98,10 @@ const renderNextHolidayTitle = ({ nextHoliday, provinceName, federal }) => {
 }
 
 const renderYearPageTitle = ({ provinceName, provinceId, federal, year }) => {
-  const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
-
   return html`<${ProvinceTitle} ...${{ provinceName, federal, year }} //>
     <p>
-      <${Button}
-        href=${`${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}/${year}`}
-        download=${provinceIdOrFederal
-          ? `canada-holidays-${provinceIdOrFederal}-${year}.ics`
-          : `canada-holidays-${year}.ics`}
-        color=${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}
-        className=${'hover-color ghost'}
-        data-event="true"
-        data-action="download-holidays"
-        data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}-${year}`}
-        >Add to your calendar<//
-      >
+      <${CalButton} provinceId=${provinceId} federal=${federal} year=${year}
+      className=${'hover-color ghost'} //>
     </p>`
 }
 

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -103,7 +103,7 @@ const renderYearPageTitle = ({ provinceName, provinceId, federal, year }) => {
   return html`<${ProvinceTitle} ...${{ provinceName, federal, year }} //>
     <p>
       <${Button}
-        href=${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}
+        href=${`${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}/${year}`}
         download=${provinceIdOrFederal
           ? `canada-holidays-${provinceIdOrFederal}-${year}.ics`
           : `canada-holidays-${year}.ics`}

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -4,6 +4,7 @@ const { theme, insideContainer, horizontalPadding, visuallyHidden } = require('.
 const NextHoliday = require('./NextHoliday.js')
 const ObservingProvinces = require('./ObservingProvinces.js')
 const ProvinceTitle = require('./ProvinceTitle.js')
+const Button = require('../components/Button.js')
 const { relativeDate } = require('../dates')
 const { shade, randomInt } = require('../utils/so.js')
 
@@ -96,6 +97,26 @@ const renderNextHolidayTitle = ({ nextHoliday, provinceName, federal }) => {
     : html`<p>${relativeDate(nextHoliday.date)}</p>`}`
 }
 
+const renderYearPageTitle = ({ provinceName, provinceId, federal, year }) => {
+  const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
+
+  return html`<${ProvinceTitle} ...${{ provinceName, federal, year }} //>
+    <p>
+      <${Button}
+        href=${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}
+        download=${provinceIdOrFederal
+          ? `canada-holidays-${provinceIdOrFederal}-${year}.ics`
+          : `canada-holidays-${year}.ics`}
+        color=${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}
+        className=${'hover-color ghost'}
+        data-event="true"
+        data-action="download-holidays"
+        data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}-${year}`}
+        >Add to your calendar<//
+      >
+    </p>`
+}
+
 const NextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, federal, year }) => {
   let bg = {
     angle: randomInt(63, 66),
@@ -111,8 +132,9 @@ const NextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, fede
       <div>
         ${nextHoliday
           ? renderNextHolidayTitle({ nextHoliday, provinceName, federal })
-          : html`<${ProvinceTitle} ...${{ provinceName, federal, year }} //>`}
-        ${federal &&
+          : renderYearPageTitle({ provinceName, provinceId, federal, year })}
+        ${nextHoliday &&
+        federal &&
         html`
           <p>
             <a href="/do-federal-holidays-apply-to-me"

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -12,7 +12,7 @@ const Button = require('./Button')
 
 const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) => css`
   padding-top: ${theme.space.md};
-  padding-bottom: ${theme.space.md};
+  padding-bottom: ${theme.space.xxs};
   border-top: 3px solid ${theme.color.greyLight};
   border-bottom: 3px solid ${theme.color.greyLight};
 

--- a/src/components/__tests__/CalButton.test.js
+++ b/src/components/__tests__/CalButton.test.js
@@ -1,0 +1,37 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils')
+
+const CalButton = require('../CalButton.js')
+
+const renderCalButton = (props = {}) => {
+  return cheerio.load(render(html` <${CalButton} ...${props} //> `))
+}
+
+test('CalButton renders properly with no properties', () => {
+  const $ = renderCalButton()
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Add to your calendar')
+  expect($('a').attr('data-action')).toEqual('download-holidays')
+  expect($('a').attr('href')).toEqual('/ics/2020')
+  expect($('a').attr('data-label')).toEqual('download-holidays-canada-2020')
+})
+
+test('CalButton renders properly for federal holidays for 2019', () => {
+  const $ = renderCalButton({ federal: true, year: 2019 })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Add to your calendar')
+  expect($('a').attr('data-action')).toEqual('download-holidays')
+  expect($('a').attr('href')).toEqual('/ics/federal/2019')
+  expect($('a').attr('data-label')).toEqual('download-holidays-federal-2019')
+})
+
+test('CalButton renders properly for provincial holidays for 2021 and a classname', () => {
+  const $ = renderCalButton({ provinceId: 'PE', year: 2021, className: 'torosaurus' })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Add to your calendar')
+  expect($('a').attr('data-action')).toEqual('download-holidays')
+  expect($('a').attr('href')).toEqual('/ics/PE/2021')
+  expect($('a').attr('data-label')).toEqual('download-holidays-PE-2021')
+  expect($('a').attr('class')).toMatch(/^torosaurus/)
+})

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -88,13 +88,15 @@ test('NextHolidayBox displays provinceName and year and "add to calendar" link',
   const $ = renderNextHolidayBox({
     nextHoliday: undefined,
     provinceName: getProvince().nameEn,
-    year: 2022,
+    provinceId: getProvince().id,
+    year: 2021,
   })
 
   expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual('Prince Edward Islandstatutory Holidays in 2022')
+  expect($('h1').text()).toEqual('Prince Edward Islandstatutory Holidays in 2021')
   expect($('h1 + p').length).toBe(1)
   expect($('h1 ~ p').text()).toEqual('Add to your calendar')
+  expect($('h1 ~ p a').attr('href')).toEqual('/ics/PE/2021')
 })
 
 test('NextHolidayBox displays provinceName and year and "add to calendar" link for federal holidays when no next holiday', () => {
@@ -107,4 +109,17 @@ test('NextHolidayBox displays provinceName and year and "add to calendar" link f
   expect($('div h1').length).toBe(1)
   expect($('h1').text()).toEqual('CanadaFederal statutory holidays in 2022')
   expect($('h1 ~ p').text()).toEqual('Add to your calendar')
+  expect($('h1 ~ p a').attr('href')).toEqual('/ics/federal/2022')
+})
+
+test('NextHolidayBox displays provinceName and year and "add to calendar" link for Canada when no next holiday', () => {
+  const $ = renderNextHolidayBox({
+    nextHoliday: undefined,
+    year: 2019,
+  })
+
+  expect($('div h1').length).toBe(1)
+  expect($('h1').text()).toEqual('Canadastatutory Holidays in 2019')
+  expect($('h1 ~ p').text()).toEqual('Add to your calendar')
+  expect($('h1 ~ p a').attr('href')).toEqual('/ics/2019')
 })

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -84,7 +84,7 @@ test('NextHolidayBox displays next holiday properly for a given province', () =>
   expect($('h1 + p').text()).toMatch(/That’s in (about )?(\d\d days|\d month(s)?)/)
 })
 
-test('NextHolidayBox displays provinceName and year when no next holiday', () => {
+test('NextHolidayBox displays provinceName and year and "add to calendar" link', () => {
   const $ = renderNextHolidayBox({
     nextHoliday: undefined,
     provinceName: getProvince().nameEn,
@@ -93,10 +93,11 @@ test('NextHolidayBox displays provinceName and year when no next holiday', () =>
 
   expect($('div h1').length).toBe(1)
   expect($('h1').text()).toEqual('Prince Edward Islandstatutory Holidays in 2022')
-  expect($('h1 + p').length).toBe(0)
+  expect($('h1 + p').length).toBe(1)
+  expect($('h1 ~ p').text()).toEqual('Add to your calendar')
 })
 
-test('NextHolidayBox displays provinceName and year for federal holidays when no next holiday', () => {
+test('NextHolidayBox displays provinceName and year and "add to calendar" link for federal holidays when no next holiday', () => {
   const $ = renderNextHolidayBox({
     nextHoliday: undefined,
     federal: true,
@@ -105,5 +106,5 @@ test('NextHolidayBox displays provinceName and year for federal holidays when no
 
   expect($('div h1').length).toBe(1)
   expect($('h1').text()).toEqual('CanadaFederal statutory holidays in 2022')
-  expect($('h1 + p').text()).toEqual('Find out who gets federal statutory holidays')
+  expect($('h1 ~ p').text()).toEqual('Add to your calendar')
 })

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -179,7 +179,7 @@ const Province = ({
                     className=${'ghost'}
                     data-event="true"
                     data-action="download-holidays"
-                    data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}`}
+                    data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}-${year}`}
                     >Add to your calendar<//
                   >
                 </div>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -6,7 +6,7 @@ const DateHtml = require('../components/DateHtml.js')
 const NextHolidayBox = require('../components/NextHolidayBox.js')
 const ProvincePicker = require('../components/ProvincePicker.js')
 const SummaryTable = require('../components/SummaryTable.js')
-const Button = require('../components/Button.js')
+const CalButton = require('../components/CalButton.js')
 
 const styles = ({ accent = theme.color.red } = {}) => css`
   div.past {
@@ -170,18 +170,8 @@ const Province = ({
                   <span class=${visuallyHidden}> statutory</span> holidays in ${year}
                 </h2>
                 <div>
-                  <${Button}
-                    href=${federal ? '/ics/federal' : provinceId ? `/ics/${provinceId}` : '/ics'}
-                    download=${provinceIdOrFederal
-                      ? `canada-holidays-${provinceIdOrFederal}-${year}.ics`
-                      : `canada-holidays-${year}.ics`}
-                    color=${provinceIdOrFederal ? theme.color[provinceIdOrFederal] : {}}
-                    className=${'ghost'}
-                    data-event="true"
-                    data-action="download-holidays"
-                    data-label=${`download-holidays-${provinceIdOrFederal || 'canada'}-${year}`}
-                    >Add to your calendar<//
-                  >
+                  <${CalButton} provinceId=${provinceId} federal=${federal} year=${year}
+                  className=${'ghost'} //>
                 </div>
               </div>`}
             <//>

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -44,6 +44,40 @@ describe('Test ics responses', () => {
     })
   })
 
+  describe('Test /ics/:year response', () => {
+    const INVALID_YEARS = ['1', 'false', 'diplodocus']
+    INVALID_YEARS.map((invalidYear) => {
+      test(`it should return 302 for badly formatted year "/ics/${invalidYear}"`, async () => {
+        // this is because it matches the "provinceId"
+        const response = await request(app).get(`/ics/${invalidYear}`)
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toBe(`/province/${invalidYear}`)
+      })
+    })
+
+    const BAD_YEARS = ['2016', '2017', '2023', '2024']
+    BAD_YEARS.map((badYear) => {
+      test(`it should return 302 for unsupported year "/ics/${badYear}"`, async () => {
+        const response = await request(app).get(`/ics/${badYear}`)
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toBe('/')
+      })
+    })
+
+    test(`it should return 302 for current year "/ics/${currentYear}"`, async () => {
+      const response = await request(app).get(`/ics/${currentYear}`)
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe('/ics')
+    })
+
+    GOOD_YEARS.map((goodYear) => {
+      test(`it should return 200 for supported year "/ics/${goodYear}"`, async () => {
+        const response = await request(app).get(`/ics/${goodYear}`)
+        expect(response.statusCode).toBe(200)
+      })
+    })
+  })
+
   describe('Test /ics/*/:year response', () => {
     const paths = ['AB', 'federal']
     paths.map((path) => {

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -3,12 +3,8 @@ const db = require('sqlite')
 const Promise = require('bluebird')
 const app = require('../../server.js')
 const { ALLOWED_YEARS } = require('../../config/vars.config')
-const { getCurrentHolidayYear } = require('../../utils')
 
 describe('Test ics responses', () => {
-  const currentYear = getCurrentHolidayYear()
-  const GOOD_YEARS = ALLOWED_YEARS.filter((y) => y !== currentYear)
-
   beforeAll(async () => {
     await Promise.resolve()
       // First, try to open the database
@@ -24,34 +20,32 @@ describe('Test ics responses', () => {
   })
 
   describe('Test /ics response', () => {
-    test('it should return 200', async () => {
+    test('it should return 404', async () => {
       const response = await request(app).get('/ics')
-      expect(response.statusCode).toBe(200)
+      expect(response.statusCode).toBe(404)
     })
   })
 
   describe('Test /ics/federal response', () => {
-    test('it should return 200', async () => {
+    test('it should return 404', async () => {
       const response = await request(app).get('/ics/federal')
-      expect(response.statusCode).toBe(200)
+      expect(response.statusCode).toBe(404)
     })
   })
 
   describe('Test /ics/AB response', () => {
-    test('it should return 200', async () => {
+    test('it should return 404', async () => {
       const response = await request(app).get('/ics/AB')
-      expect(response.statusCode).toBe(200)
+      expect(response.statusCode).toBe(404)
     })
   })
 
   describe('Test /ics/:year response', () => {
     const INVALID_YEARS = ['1', 'false', 'diplodocus']
     INVALID_YEARS.map((invalidYear) => {
-      test(`it should return 302 for badly formatted year "/ics/${invalidYear}"`, async () => {
-        // this is because it matches the "provinceId"
+      test(`it should return 404 for badly formatted year "/ics/${invalidYear}"`, async () => {
         const response = await request(app).get(`/ics/${invalidYear}`)
-        expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(`/province/${invalidYear}`)
+        expect(response.statusCode).toBe(404)
       })
     })
 
@@ -64,13 +58,7 @@ describe('Test ics responses', () => {
       })
     })
 
-    test(`it should return 302 for current year "/ics/${currentYear}"`, async () => {
-      const response = await request(app).get(`/ics/${currentYear}`)
-      expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe('/ics')
-    })
-
-    GOOD_YEARS.map((goodYear) => {
+    ALLOWED_YEARS.map((goodYear) => {
       test(`it should return 200 for supported year "/ics/${goodYear}"`, async () => {
         const response = await request(app).get(`/ics/${goodYear}`)
         expect(response.statusCode).toBe(200)
@@ -99,13 +87,7 @@ describe('Test ics responses', () => {
         })
       })
 
-      test(`it should return 302 for current year "/ics/${path}/${currentYear}"`, async () => {
-        const response = await request(app).get(`/ics/${path}/${currentYear}`)
-        expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(`/ics/${path}`)
-      })
-
-      GOOD_YEARS.map((goodYear) => {
+      ALLOWED_YEARS.map((goodYear) => {
         test(`it should return 200 for supported year "/ics/${path}/${goodYear}"`, async () => {
           const response = await request(app).get(`/ics/${path}/${goodYear}`)
           expect(response.statusCode).toBe(200)
@@ -115,10 +97,9 @@ describe('Test ics responses', () => {
   })
 
   describe('Test /ics/fake response', () => {
-    test('it should return 302', async () => {
+    test('it should return 404', async () => {
       const response = await request(app).get('/ics/fake')
-      expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe('/province/fake')
+      expect(response.statusCode).toBe(404)
     })
   })
 })

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -2,8 +2,13 @@ const request = require('supertest')
 const db = require('sqlite')
 const Promise = require('bluebird')
 const app = require('../../server.js')
+const { ALLOWED_YEARS } = require('../../config/vars.config')
+const { getCurrentHolidayYear } = require('../../utils')
 
 describe('Test ics responses', () => {
+  const currentYear = getCurrentHolidayYear()
+  const GOOD_YEARS = ALLOWED_YEARS.filter((y) => y !== currentYear)
+
   beforeAll(async () => {
     await Promise.resolve()
       // First, try to open the database
@@ -11,7 +16,7 @@ describe('Test ics responses', () => {
       // Update db schema to the latest version using SQL-based migrations
       .then(() => db.migrate()) // <=
       // Display error message if something went wrong
-      .catch(err => console.error(err.stack)) // eslint-disable-line no-console
+      .catch((err) => console.error(err.stack)) // eslint-disable-line no-console
   })
 
   afterAll(() => {
@@ -36,6 +41,38 @@ describe('Test ics responses', () => {
     test('it should return 200', async () => {
       const response = await request(app).get('/ics/AB')
       expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('Test /ics/AB/:year response', () => {
+    const INVALID_YEARS = ['1', 'false', 'diplodocus']
+    INVALID_YEARS.map((invalidYear) => {
+      test(`it should return 404 for badly formatted year "/ics/AB/${invalidYear}"`, async () => {
+        const response = await request(app).get(`/ics/AB/${invalidYear}`)
+        expect(response.statusCode).toBe(404)
+      })
+    })
+
+    const BAD_YEARS = ['2016', '2017', '2023', '2024']
+    BAD_YEARS.map((badYear) => {
+      test(`it should return 302 for unsupported year "/ics/AB/${badYear}"`, async () => {
+        const response = await request(app).get(`/ics/AB/${badYear}`)
+        expect(response.statusCode).toBe(302)
+        expect(response.headers.location).toBe('/province/AB')
+      })
+    })
+
+    test(`it should return 302 for current year "/ics/AB/${currentYear}"`, async () => {
+      const response = await request(app).get(`/ics/AB/${currentYear}`)
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe('/ics/AB')
+    })
+
+    GOOD_YEARS.map((goodYear) => {
+      test(`it should return 200 for supported year "/ics/AB/${goodYear}"`, async () => {
+        const response = await request(app).get(`/ics/AB/${goodYear}`)
+        expect(response.statusCode).toBe(200)
+      })
     })
   })
 

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -44,34 +44,38 @@ describe('Test ics responses', () => {
     })
   })
 
-  describe('Test /ics/AB/:year response', () => {
-    const INVALID_YEARS = ['1', 'false', 'diplodocus']
-    INVALID_YEARS.map((invalidYear) => {
-      test(`it should return 404 for badly formatted year "/ics/AB/${invalidYear}"`, async () => {
-        const response = await request(app).get(`/ics/AB/${invalidYear}`)
-        expect(response.statusCode).toBe(404)
+  describe('Test /ics/*/:year response', () => {
+    const paths = ['AB', 'federal']
+    paths.map((path) => {
+      const INVALID_YEARS = ['1', 'false', 'diplodocus']
+      INVALID_YEARS.map((invalidYear) => {
+        test(`it should return 404 for badly formatted year "/ics/${path}/${invalidYear}"`, async () => {
+          const response = await request(app).get(`/ics/${path}/${invalidYear}`)
+          expect(response.statusCode).toBe(404)
+        })
       })
-    })
 
-    const BAD_YEARS = ['2016', '2017', '2023', '2024']
-    BAD_YEARS.map((badYear) => {
-      test(`it should return 302 for unsupported year "/ics/AB/${badYear}"`, async () => {
-        const response = await request(app).get(`/ics/AB/${badYear}`)
+      const BAD_YEARS = ['2016', '2017', '2023', '2024']
+      BAD_YEARS.map((badYear) => {
+        test(`it should return 302 for unsupported year "/ics/${path}/${badYear}"`, async () => {
+          const response = await request(app).get(`/ics/${path}/${badYear}`)
+          expect(response.statusCode).toBe(302)
+          const expectedPath = path && path !== 'federal' ? `/province/${path}` : `/${path}`
+          expect(response.headers.location).toBe(expectedPath)
+        })
+      })
+
+      test(`it should return 302 for current year "/ics/${path}/${currentYear}"`, async () => {
+        const response = await request(app).get(`/ics/${path}/${currentYear}`)
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe('/province/AB')
+        expect(response.headers.location).toBe(`/ics/${path}`)
       })
-    })
 
-    test(`it should return 302 for current year "/ics/AB/${currentYear}"`, async () => {
-      const response = await request(app).get(`/ics/AB/${currentYear}`)
-      expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe('/ics/AB')
-    })
-
-    GOOD_YEARS.map((goodYear) => {
-      test(`it should return 200 for supported year "/ics/AB/${goodYear}"`, async () => {
-        const response = await request(app).get(`/ics/AB/${goodYear}`)
-        expect(response.statusCode).toBe(200)
+      GOOD_YEARS.map((goodYear) => {
+        test(`it should return 200 for supported year "/ics/${path}/${goodYear}"`, async () => {
+          const response = await request(app).get(`/ics/${path}/${goodYear}`)
+          expect(response.statusCode).toBe(200)
+        })
       })
     })
   })

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -3,13 +3,7 @@ const router = express.Router()
 const db = require('sqlite')
 const ics = require('ics')
 const createError = require('http-errors')
-const {
-  dbmw,
-  isProvinceId,
-  getCurrentHolidayYear,
-  checkRedirectIfCurrentYear,
-  param2query,
-} = require('../utils/index')
+const { dbmw, isProvinceId, getCurrentHolidayYear, param2query } = require('../utils/index')
 const { ALLOWED_YEARS } = require('../config/vars.config')
 const {
   startDate,
@@ -67,16 +61,9 @@ const downloadICS = ({ req, res, modifier = null, year = getCurrentHolidayYear()
   }
 }
 
-router.get('/ics', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const holidays = res.locals.rows.map((h) => formatNationalEvent(h))
-
-  ics.createEvents(holidays, downloadICS({ req, res }))
-})
-
 router.get(
   '/ics/:year(\\d{4})',
   param2query('year'),
-  checkRedirectIfCurrentYear,
   dbmw(db, getHolidaysWithProvinces),
   (req, res) => {
     let year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
@@ -88,17 +75,9 @@ router.get(
   },
 )
 
-router.get('/ics/federal', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  const filteredRows = res.locals.rows.filter((h) => h.federal)
-  const holidays = filteredRows.map((h) => formatProvinceEvent(h))
-
-  ics.createEvents(holidays, downloadICS({ req, res, modifier: 'federal' }))
-})
-
 router.get(
   '/ics/federal/:year(\\d{4})',
   param2query('year'),
-  checkRedirectIfCurrentYear,
   dbmw(db, getHolidaysWithProvinces),
   (req, res) => {
     let year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
@@ -111,23 +90,9 @@ router.get(
   },
 )
 
-router.get('/ics/:provinceId', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  let provinceId = req.params.provinceId
-  if (!isProvinceId(provinceId)) {
-    return res.redirect(`/province/${provinceId}`)
-  }
-
-  provinceId = provinceId.toUpperCase()
-  const filteredRows = res.locals.rows.filter((h) => h.provinces.find((p) => p.id === provinceId))
-  const holidays = filteredRows.map((h) => formatProvinceEvent(h))
-
-  ics.createEvents(holidays, downloadICS({ req, res, modifier: provinceId }))
-})
-
 router.get(
   '/ics/:provinceId/:year(\\d{4})',
   param2query('year'),
-  checkRedirectIfCurrentYear,
   dbmw(db, getHolidaysWithProvinces),
   (req, res) => {
     let provinceId = req.params.provinceId

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -75,6 +75,22 @@ router.get('/ics/federal', dbmw(db, getHolidaysWithProvinces), (req, res) => {
   ics.createEvents(holidays, downloadICS({ req, res, modifier: 'federal' }))
 })
 
+router.get(
+  '/ics/federal/:year(\\d{4})',
+  param2query('year'),
+  checkRedirectIfCurrentYear,
+  dbmw(db, getHolidaysWithProvinces),
+  (req, res) => {
+    let year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
+    if (!year) return res.redirect('/federal')
+
+    const filteredRows = res.locals.rows.filter((h) => h.federal)
+    const holidays = filteredRows.map((h) => formatProvinceEvent(h))
+
+    ics.createEvents(holidays, downloadICS({ req, res, modifier: 'federal', year }))
+  },
+)
+
 router.get('/ics/:provinceId', dbmw(db, getHolidaysWithProvinces), (req, res) => {
   let provinceId = req.params.provinceId
   if (!isProvinceId(provinceId)) {

--- a/src/utils/__tests__/ics.test.js
+++ b/src/utils/__tests__/ics.test.js
@@ -4,6 +4,7 @@ const {
   getNationalDescription,
   getProvinceDescription,
   getTitle,
+  getUid,
 } = require('../ics')
 
 describe('Test startDate', () => {
@@ -61,7 +62,7 @@ describe('Test getTitle', () => {
   test('returns title with 12 bracketed province IDs for a holiday with 12 provinces', () => {
     // missing "AB"
     const ids = ['BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT']
-    const provinces = ids.map(v => {
+    const provinces = ids.map((v) => {
       return { id: v }
     })
     const holidayStub = { provinces, ...name }
@@ -147,5 +148,113 @@ describe('Test getProvinceDescription', () => {
     expect(getProvinceDescription(holidayStub)).toMatch(
       'Observed by AB, BC, MB, and federal industries.',
     )
+  })
+})
+
+describe('Test getUid', () => {
+  test('Returns a hash for a holiday object', () => {
+    const holiday = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+    }
+    const uid = getUid(holiday)
+    expect(uid).toEqual('r+uDBpoFv1GNOoweYULVnz0lF8s=')
+  })
+
+  test('Different ids for different date, different title', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+    }
+    const holiday2 = {
+      date: '2022-10-10',
+      nameEn: 'Thanksgiving',
+    }
+
+    expect(getUid(holiday1)).not.toEqual(getUid(holiday2))
+  })
+
+  test('Different ids for different date, same title', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+    }
+    const holiday2 = {
+      date: '2022-02-28',
+      nameEn: 'Family Day',
+    }
+
+    expect(getUid(holiday1)).not.toEqual(getUid(holiday2))
+  })
+
+  test('Different ids for same date, different title', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+    }
+    const holiday2 = {
+      date: '2022-02-21',
+      nameEn: 'Louis Riel Day',
+    }
+
+    expect(getUid(holiday1)).not.toEqual(getUid(holiday2))
+  })
+
+  test('Different ids for same date, same title, different provinces', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+      provinces: [{ id: 'ON' }],
+    }
+    const holiday2 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+      provinces: [{ id: 'BC' }],
+    }
+
+    expect(getUid(holiday1)).not.toEqual(getUid(holiday2))
+  })
+
+  test('Different ids for same date, same title, one federal', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+      federal: true,
+    }
+    const holiday2 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+      federal: false,
+    }
+
+    expect(getUid(holiday1)).not.toEqual(getUid(holiday2))
+  })
+
+  test('Same ids for same date, same title, same provinces', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+      provinces: [{ id: 'ON' }],
+    }
+    const holiday2 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+      provinces: [{ id: 'ON' }],
+    }
+
+    expect(getUid(holiday1)).toEqual(getUid(holiday2))
+  })
+
+  test('Same ids for same date, same title, no provinces', () => {
+    const holiday1 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+    }
+    const holiday2 = {
+      date: '2022-02-21',
+      nameEn: 'Family Day',
+    }
+
+    expect(getUid(holiday1)).toEqual(getUid(holiday2))
   })
 })


### PR DESCRIPTION
This PR does a bunch of things, actually.

1. Notably, it adds a "download holidays" link to the "years" pages. Had to rewrite the ICS routes pretty extensively to get them to support that.
2. Also fixes a bug where events on the same date wouldn't be added to the calendar (just the first one)
3. Finally, removes some padding where there was too much

I guess that's not too many things, but there was a lot of refactoring involved. 

## Screenshots

| before | after |
|--------|-------|
| <img width="1246" alt="Screen Shot 2020-04-23 at 3 10 14 PM" src="https://user-images.githubusercontent.com/2454380/80139924-3b40ed00-8575-11ea-9916-ddd2d0298d64.png">  |  <img width="1246" alt="Screen Shot 2020-04-23 at 3 10 12 PM" src="https://user-images.githubusercontent.com/2454380/80139933-3ed47400-8575-11ea-8d64-9d9653f589d3.png">  |


