### PR TITLE
Add OpenAPI tests to the API 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,9 @@
 - make API to return CSV format
   - page for CSV downloads
 - swagger api docs?
+  - add them
+  - test them
+  - write about them
 - add a print button?
 - https://matthewsmith.io/blog/how-to-set-up-cache-busting-in-express
 - list of holidays

--- a/TODO.md
+++ b/TODO.md
@@ -3,9 +3,8 @@
 - Add years to dates on years pages?
 - make API to return CSV format
   - page for CSV downloads
-- swagger api docs?
-  - add them
-  - test them
+- swagger api spec
+  - swagger ui?
   - write about them
 - add a print button?
 - https://matthewsmith.io/blog/how-to-set-up-cache-busting-in-express
@@ -13,6 +12,9 @@
 
 # DONE
 
+- swagger api spec
+  - add them
+  - test them
 - /favicon.ico less 404s
 - CORS for the API
 - server logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,19 @@
 {
   "name": "hols",
-  "version": "2.1.0",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
+      "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.0",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -973,6 +983,11 @@
       "resolved": "https://registry.npmjs.org/@jsbits/easter-day/-/easter-day-1.0.1.tgz",
       "integrity": "sha512-T3MlypX5BblFBDhUpacTqZ9TY7z2/RZZFhQkavakrCNuMn3NBBrGgHEsz0T2Xcjx5ZTq4sNC2YYrmN65PPRxAA=="
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.2.tgz",
+      "integrity": "sha512-qS/a24RA5FEoiJS9wiv6Pwg2c/kiUo3IVUQcfeM9JvsR6pM8Yx+yl/6xWYLckZCT5jpLNhslgjiA8p/XcGyMRQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1336,6 +1351,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1383,7 +1403,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1700,6 +1719,15 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1912,6 +1940,28 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
       "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -1965,6 +2015,11 @@
           "dev": true
         }
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "callsites": {
       "version": "3.1.0",
@@ -2232,6 +2287,51 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -2441,6 +2541,16 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.12.0.tgz",
       "integrity": "sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw=="
     },
+    "deasync": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+      "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^1.7.1"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2564,6 +2674,28 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
     },
     "diff-sequences": {
       "version": "25.2.6",
@@ -2926,8 +3058,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.3.1",
@@ -3125,6 +3256,37 @@
         "express": "^4.15.3"
       }
     },
+    "express-openapi-validator": {
+      "version": "3.12.7",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-3.12.7.tgz",
+      "integrity": "sha512-6r0vnuzv2sUOZZSj3fMSgWFN8CfiWZV6KXrBfm0AGsLKsyW41zUHTwASlnwDiF5z/TeLpH5w4rgisneG1G1fBw==",
+      "requires": {
+        "ajv": "^6.12.2",
+        "content-type": "^1.0.4",
+        "deasync": "^0.1.19",
+        "js-yaml": "^3.13.1",
+        "json-schema-ref-parser": "^8.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0",
+        "lodash.zipobject": "^4.1.3",
+        "media-typer": "^1.1.0",
+        "multer": "^1.4.2",
+        "ono": "^7.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "dependencies": {
+        "media-typer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+          "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+        },
+        "path-to-regexp": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+          "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3279,6 +3441,12 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -5792,7 +5960,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5877,6 +6044,14 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-ref-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
+      "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "8.0.0"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5979,11 +6154,26 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.zipobject": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz",
+      "integrity": "sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg="
     },
     "lolex": {
       "version": "5.1.2",
@@ -6190,6 +6380,28 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        }
+      }
+    },
     "multipipe": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
@@ -6275,6 +6487,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
+    },
+    "node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+      "optional": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -6551,6 +6769,14 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "ono": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-7.1.2.tgz",
+      "integrity": "sha512-es7Gfr+OGNFwiYpyHCLgBF+p/RA0qYbWysQKlZbLvvUBis5BygEs8TVJ4r+SgHDfagOgONhaAl6Y4JLy++0MTw==",
+      "requires": {
+        "@jsdevtools/ono": "7.1.2"
       }
     },
     "optionator": {
@@ -7719,8 +7945,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sql-template-strings": {
       "version": "2.2.2",
@@ -7800,6 +8025,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-length": {
       "version": "3.1.0",
@@ -8294,6 +8524,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "express-http-to-https": "^1.1.4",
+    "express-openapi-validator": "^3.12.7",
     "helmet": "^3.22.0",
     "htm": "^3.0.4",
     "http-errors": "^1.7.3",

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Canada Holidays API
-  version: '1.0'
+  version: 1.0.2
   description: 'This API that lists all 28 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
@@ -60,11 +60,11 @@ paths:
                     message: 'Hello / Bonjour! Welcome to the Canada Holidays API / Bienvenue dans l’API canadienne des jours fériés'
                     _links:
                       self:
-                        href: 'http://localhost:3000/api/v1/'
+                        href: 'https://canada-holidays.ca/api/v1/'
                       holidays:
-                        href: 'http://localhost:3000/api/v1/holidays'
+                        href: 'https://canada-holidays.ca/api/v1/holidays'
                       provinces:
-                        href: 'http://localhost:3000/api/v1/provinces'
+                        href: 'https://canada-holidays.ca/api/v1/provinces'
       operationId: Root
       description: Returns a welcome message.
   /api/v1/holidays:
@@ -145,11 +145,10 @@ paths:
       description: Returns Canadian public holidays. Each holiday lists the regions that observe it.
       parameters:
         - schema:
-            type: string
-            default: '2020'
-            pattern: "^\\d{4}$"
-            minLength: 4
-            maxLength: 4
+            type: integer
+            default: 2020
+            minimum: 2018
+            maximum: 2022
           in: query
           description: A calendar year
           name: year
@@ -163,7 +162,7 @@ paths:
               - 'false'
           in: query
           name: federal
-          description: 'A boolean parameter. If true, will return only federal holidays. If false, will return no federal holidays.'
+          description: 'A boolean parameter. If true or 1, will return only federal holidays. If false or 0, will return no federal holidays.'
           allowEmptyValue: true
       tags:
         - holidays
@@ -232,11 +231,10 @@ paths:
       operationId: Provinces
       parameters:
         - schema:
-            type: string
-            default: '2020'
-            pattern: "^\\d{4}$"
-            minLength: 4
-            maxLength: 4
+            type: integer
+            default: 2020
+            minimum: 2018
+            maximum: 2022
           in: query
           description: A calendar year
           name: year
@@ -300,11 +298,10 @@ paths:
       description: Returns a Canadian province or territory with its associated holidays.
       parameters:
         - schema:
-            type: string
-            default: '2020'
-            pattern: "^\\d{4}$"
-            minLength: 4
-            maxLength: 4
+            type: integer
+            default: 2020
+            minimum: 2018
+            maximum: 2022
           in: query
           description: A calendar year
           name: year
@@ -337,8 +334,6 @@ paths:
     parameters:
       - schema:
           type: integer
-          minLength: 1
-          maxLength: 28
           example: 2
           minimum: 1
           maximum: 28
@@ -392,11 +387,10 @@ paths:
       description: Returns one Canadian statutory holiday by integer id. Returns a 404 response for invalid ids.
       parameters:
         - schema:
-            type: string
-            default: '2020'
-            pattern: "^\\d{4}$"
-            minLength: 4
-            maxLength: 4
+            type: integer
+            default: 2020
+            minimum: 2018
+            maximum: 2022
           in: query
           description: A calendar year
           name: year
@@ -441,13 +435,11 @@ components:
           description: French name
           example: Journée Louis Riel
         federal:
-          type: string
+          type: number
           description: Whether this holiday is observed by federally-regulated industries.
           enum:
-            - '0'
-            - '1'
-            - 'true'
-            - 'false'
+            - 1
+            - 0
           format: binary
         provinces:
           type: array

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -278,8 +278,8 @@ paths:
                         nameEn: Victoria Day
                         nameFr: Fête de la Reine
                         federal: 1
-        '404':
-          description: Not Found
+        '400':
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -291,11 +291,11 @@ paths:
                 /holidays/100:
                   value:
                     error:
-                      status: 404
-                      message: 'Error: No holiday with id “100”'
-                      timestamp: '2020-04-27T05:41:10.710Z'
+                      status: 400
+                      message: 'Error: request.params.provinceId should be equal to one of the allowed values: AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT'
+                      timestamp: '2020-04-28T04:02:38.813Z'
       operationId: Province
-      description: Returns a Canadian province or territory with its associated holidays.
+      description: Returns a Canadian province or territory with its associated holidays. Returns a 404 response for invalid abbreviations.
       parameters:
         - schema:
             type: integer
@@ -307,7 +307,7 @@ paths:
           name: year
           allowEmptyValue: true
       tags:
-        - root
+        - provinces
     parameters:
       - schema:
           type: string
@@ -367,8 +367,8 @@ paths:
                         - id: MB
                           nameEn: Manitoba
                           nameFr: Manitoba
-        '404':
-          description: Not Found
+        '400':
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -380,9 +380,9 @@ paths:
                 /holidays/100:
                   value:
                     error:
-                      status: 404
-                      message: 'Error: No holiday with id “100”'
-                      timestamp: '2020-04-27T05:41:10.710Z'
+                      status: 400
+                      message: 'Error: request.params.holidayId should be <= 28'
+                      timestamp: '2020-04-28T03:59:56.605Z'
       operationId: Holiday
       description: Returns one Canadian statutory holiday by integer id. Returns a 404 response for invalid ids.
       parameters:
@@ -539,9 +539,10 @@ components:
       type: object
       x-examples:
         /holidays/100:
-          status: 404
-          message: 'Error: No holiday with id “100”'
-          timestamp: '2020-04-27T05:41:10.710Z'
+          error:
+            status: 400
+            message: 'Error: request.params.holidayId should be <= 28'
+            timestamp: '2020-04-28T03:59:12.427Z'
       properties:
         status:
           type: integer

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -52,6 +52,7 @@ describe('Test /api responses', () => {
   describe('Verify CORS headers', () => {
     const corsUrls = [
       '/api/v1/',
+      '/api/v1/spec',
       '/api/v1/provinces',
       '/api/v1/holidays',
       '/api/v1/provinces/AB',
@@ -70,6 +71,15 @@ describe('Test /api responses', () => {
         const response = await request(app).get(url)
         expect(response.headers['access-control-allow-origin']).toBe(undefined)
       })
+    })
+  })
+
+  describe('Test /api/spec response', () => {
+    test('it should return 200', async () => {
+      const response = await request(app).get('/api/v1/spec')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toEqual('text/yaml; charset=UTF-8')
+      expect(response.text).toMatch(/openapi: 3.0.0/)
     })
   })
 
@@ -108,7 +118,7 @@ describe('Test /api responses', () => {
 
     let json = JSON.parse(response.text)
     expect(json.message).toMatch(/Hello \/ Bonjour!/)
-    expect(Object.keys(json._links)).toEqual(['self', 'holidays', 'provinces'])
+    expect(Object.keys(json._links)).toEqual(['self', 'holidays', 'provinces', 'spec'])
   })
 
   describe('for /api/v1/provinces path', () => {

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -56,6 +56,9 @@ v1Router.get('/', (req, res) => {
       provinces: {
         href: `${protocol}://${req.get('host')}/api/v1/provinces`,
       },
+      spec: {
+        href: `${protocol}://${req.get('host')}/api/v1/spec`,
+      },
     },
   })
 })

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -7,10 +7,24 @@ const renderPage = require('../pages/_document.js')
 const { dbmw, checkProvinceIdErr } = require('../utils')
 const { getProvincesWithHolidays, getHolidaysWithProvinces } = require('../queries')
 
+// 1. Import the express-openapi-validator library
+const OpenApiValidator = require('express-openapi-validator').OpenApiValidator
+const path = require('path')
+
 router.use(cors())
 
+// 3. (optionally) Serve the OpenAPI spec
+const spec = path.join(__dirname, '../../reference/Canada-Holidays-API.v1.yaml')
+router.use('/spec', express.static(spec))
+
+new OpenApiValidator({
+  apiSpec: spec,
+  validateRequests: true, // (default)
+  validateResponses: true, // false by default
+}).installSync(router)
+
 router.get('/v1/provinces', dbmw(db, getProvincesWithHolidays), (req, res) => {
-  return res.send({ provinces: res.locals.rows })
+  return res.send({ provinc: res.locals.rows })
 })
 
 router.get(
@@ -76,6 +90,9 @@ router.get('*', (req, res) => {
 
 // eslint-disable-next-line no-unused-vars
 router.use(function (err, req, res, next) {
+  console.log('errs', err)
+  console.log('json', err.toJSON())
+  console.log('string', err.toString())
   return res.send({
     error: {
       status: res.statusCode,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -22,46 +22,49 @@ new OpenApiValidator({
   apiSpec: spec,
   validateRequests: true, // (default)
   validateResponses: true, // false by default
-}).installSync(v1Router)
-
-v1Router.get('/provinces', dbmw(db, getProvincesWithHolidays), (req, res) => {
-  return res.send({ provinces: res.locals.rows })
 })
+  .install(v1Router)
+  .then(() => {
+    // 5. Define routes using Express
+    v1Router.get('/provinces', dbmw(db, getProvincesWithHolidays), (req, res) => {
+      return res.send({ provinces: res.locals.rows })
+    })
 
-v1Router.get('/provinces/:provinceId', dbmw(db, getProvincesWithHolidays), (req, res) => {
-  return res.send({ province: res.locals.rows[0] })
-})
+    v1Router.get('/provinces/:provinceId', dbmw(db, getProvincesWithHolidays), (req, res) => {
+      return res.send({ province: res.locals.rows[0] })
+    })
 
-v1Router.get('/holidays', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  return res.send({ holidays: res.locals.rows })
-})
+    v1Router.get('/holidays', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+      return res.send({ holidays: res.locals.rows })
+    })
 
-v1Router.get('/holidays/:holidayId', dbmw(db, getHolidaysWithProvinces), (req, res) => {
-  return res.send({ holiday: res.locals.rows[0] })
-})
+    v1Router.get('/holidays/:holidayId', dbmw(db, getHolidaysWithProvinces), (req, res) => {
+      return res.send({ holiday: res.locals.rows[0] })
+    })
 
-v1Router.get('/', (req, res) => {
-  const protocol = req.get('host').includes('localhost') ? 'http' : 'https'
+    v1Router.get('/', (req, res) => {
+      const protocol = req.get('host').includes('localhost') ? 'http' : 'https'
 
-  res.send({
-    message:
-      'Hello / Bonjour! Welcome to the Canada Holidays API / Bienvenue dans l’API canadienne des jours fériés',
-    _links: {
-      self: {
-        href: `${protocol}://${req.get('host')}/api/v1/`,
-      },
-      holidays: {
-        href: `${protocol}://${req.get('host')}/api/v1/holidays`,
-      },
-      provinces: {
-        href: `${protocol}://${req.get('host')}/api/v1/provinces`,
-      },
-      spec: {
-        href: `${protocol}://${req.get('host')}/api/v1/spec`,
-      },
-    },
+      res.send({
+        message:
+          'Hello / Bonjour! Welcome to the Canada Holidays API / Bienvenue dans l’API canadienne des jours fériés',
+        _links: {
+          self: {
+            href: `${protocol}://${req.get('host')}/api/v1/`,
+          },
+          holidays: {
+            href: `${protocol}://${req.get('host')}/api/v1/holidays`,
+          },
+          provinces: {
+            href: `${protocol}://${req.get('host')}/api/v1/provinces`,
+          },
+          spec: {
+            href: `${protocol}://${req.get('host')}/api/v1/spec`,
+          },
+        },
+      })
+    })
   })
-})
 
 apiRouter.get('/', (req, res) => {
   return res.send(


### PR DESCRIPTION
Added the express openapi validator

check it out: https://www.npmjs.com/package/express-openapi-validator

Added it as a middleware to my API routes: means it checks the requests and responses to conform to the spec itself. Hopefully keeps the spec documentation actually aligned with the working code.

Lots of my error messages are worse now but I have no users so whatever.
