### PR TITLE
Update API docs 

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,49 +1,67 @@
 # Canada Holidays API
 
-Canada has public holidays, but when are they? UK people know when [UK bank holidays](https://www.gov.uk/bank-holidays) are — Canadians who can’t yet move to Liverpool still deserve to know when they can sleep in.
+The <a href="https://canada-holidays.ca/api/v1/" target="_blank">Canada Holidays API</a> lists all 28 public holidays for all 13 provinces and territories in Canada, including federal holidays.
 
-This is an API that lists
+**👉 <a href="https://canada-holidays.ca/api/v1/" target="_blank">https://canada-holidays.ca/api/v1/</a>**
 
-- all 27 public holidays in Canada
-- all 13 provinces and territories in Canada
-- which provinces/territories observe which holidays
-- which holidays are federal holidays
-- returns holidays for years: 2019, 2020, 2021
-- (TODO: more years)
+Features:
 
-I scraped the data from [the Canadian holidays page on Wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_Canada), so if you notice an issue, please edit the page yourself and then [email me](mailto:paul@pcraig3.ca) so that I know.
+- Returns holidays with associated regions
+- Returns regions with associated holidays
+- Returns only federal holidays
+- Returns only national holidays
+- Returns "next" holiday for each region
+- Returns holidays for years: `2018`, `2019`, `2020`, `2021`, `2022`
 
-This is a node API, so it's pretty straightforward. Using an SQL migrations file, we put all our data into an in-memory SQLite database and then we do reads.
+Plus(!) check out all these goodies you get ✨ for free ✨:
 
-The [Government of Canada API guidance](https://www.canada.ca/en/government/publicservice/modernizing/government-canada-standards-apis.html) wants a slightly more rigourous API design, but "design with users" is actually the first rule and none of them have complained yet. ([Be the first](mailto:paul@pcraig3.ca)!)
+- It’s free (✨)
+- <a href="https://twitter.com/pcraig3" target="_blank">Dedicated support channel</a>
+- Kind of bilingual (EN & FR)
+- Pretty much compliant with <a href="https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/government-canada-standards-apis.html" target="_blank">the Government of Canada Standards on APIs</a> (heck yes 🤙)
+- Open source which is cool if you’re a nerd
+- Documented with an OpenAPI spec which is _even more_ cool for _even nerdier_ nerds
+
+Definitely use it for your billions of dollars mission-critical system.
 
 ## Docs
 
-There are 5 endpoints.
-All are `GET` requests.
-As much as users would like to, it’s not yet possible to `PUT` additional public holidays.
-None of the fields ever return `null` values.
+If you know your way around a REST API with JSON responses, you’re in good shape. There's an OpenAPI spec describing the API, and a more prose-y overview if you keep reading. Both should be equivalent — the spec is more exact but the overview is easier to skim.
+
+### OpenAPI (formerly Swagger)
+
+<a href="https://swagger.io/docs/specification/about/" target="_blank">The OpenAPI Specification</a> is a broadly-adopted industry standard for describing APIs. The OpenAPI spec for this API is in a few places.
+
+- <a href="https://github.com/pcraig3/hols/blob/master/reference/Canada-Holidays-API.v1.yaml" target="_blank">`Canada-Holidays-API.v1.yaml`</a> on GitHub
+- At <a href="https://canada-holidays.ca/api/v1/spec" target="_blank">https://canada-holidays.ca/api/v1/spec</a>
+- <a href="https://app.swaggerhub.com/apis/pcraig3/canada-holidays/" target="_blank">`canada-holidays`</a> on SwaggerHub
+
+The SwaggerHub link includes an API explorer so you can give it a spin before you drive it off the lot.
+
+### Overview
+
+There are 5 endpoints. All are `GET` requests. As much as I know you would love to, it’s not yet possible to `PUT` additional public holidays. None of the fields ever return `null` values.
 
 - [`/api/v1`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1--root)
 - [`/api/v1/provinces`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1provinces--get-all-provinces-and-territories)
-- [`/api/v1/provinces/{id}`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1provincesid--get-one-province-or-territory)
+- [`/api/v1/provinces/{provinceId}`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1provincesid--get-one-province-or-territory)
 - [`/api/v1/holidays`](https://github.com/pcraig3/hols/blob/master/API.md#apiv1holidays--get-all-holidays)
-- [`/api/v1/holidays/{id}`](https://github.com/pcraig3/hols/blob/master/API.md#v1holidaysid--get-one-holiday)
+- [`/api/v1/holidays/{holidayId}`](https://github.com/pcraig3/hols/blob/master/API.md#v1holidaysid--get-one-holiday)
 
-### Filters
+#### Query parameters
 
-There are 2 filter values you can use. Probably not on the root route but on others they will work.
+There are 2 query parameters values you can use. Probably not on the root route but on others they will work.
 
-1. `?year=2019|2020|2021`. Defaults to current year.
-2. `?federal=true|false`. `true` returns only federal holidays; `false` returns _everything but_ federal holidays.
+1. `?year=2018|2019|2020|2021|2022`. Defaults to current year.
+2. `?federal=true|1|false|0`. `true` or `1` returns only federal holidays; `false` or `0` returns _everything but_ federal holidays.
 
 You can combine them and they will work (eg, `/api/v1/holidays?year=2021&federal=true`).
 
-### Routes
+#### Routes
 
-#### `/api/v1/` → root
+##### `/api/v1/` → root
 
-Returns a welcome message and links to the lists of data.
+Returns a welcome message and navigational links.
 
 <details>
 <summary>Example response</summary>
@@ -59,6 +77,9 @@ Returns a welcome message and links to the lists of data.
     },
     "provinces": {
       "href": "url"
+    },
+    "spec": {
+      "href": "url"
     }
   },
   "message": "welcome message"
@@ -67,7 +88,7 @@ Returns a welcome message and links to the lists of data.
 
 </details>
 
-#### `/api/v1/provinces` → GET all provinces and territories
+##### `/api/v1/provinces` → GET all provinces and territories
 
 Returns a list of provinces and territories in Canada. Each province or territory lists its associated holidays.
 
@@ -106,9 +127,9 @@ Returns a list of provinces and territories in Canada. Each province or territor
 
 </details>
 
-#### `/api/v1/provinces/{id}` → GET one province or territory
+##### `/api/v1/provinces/{provinceId}` → GET one province or territory
 
-Returns one province or territory in Canada by [two-letter postal abbreviations](https://en.wikipedia.org/wiki/Canadian_postal_abbreviations_for_provinces_and_territories#Names_and_abbreviations). Case insensitive. Returns [a `400` response](https://github.com/pcraig3/holidays-canada#errors) for invalid `id`s.
+Returns one province or territory in Canada by [two-letter postal abbreviations](https://en.wikipedia.org/wiki/Canadian_postal_abbreviations_for_provinces_and_territories#Names_and_abbreviations). Must be uppercase. Returns [a `400` response](https://github.com/pcraig3/holidays-canada#errors) for invalid `provinceId`s.
 
 <details>
 <summary>Example response</summary>
@@ -142,7 +163,7 @@ Returns one province or territory in Canada by [two-letter postal abbreviations]
 
 </details>
 
-#### `/api/v1/holidays` → GET all holidays
+##### `/api/v1/holidays` → GET all holidays
 
 Returns a list of Canadian public holidays. Each holiday lists the regions that observe it.
 
@@ -174,9 +195,9 @@ Returns a list of Canadian public holidays. Each holiday lists the regions that 
 
 </details>
 
-#### `/v1/holidays/{id}` → GET one holiday
+##### `/v1/holidays/{holidayId}` → GET one holiday
 
-Returns one Canadian statutory holiday by integer id. Returns [a `404` response](https://github.com/pcraig3/holidays-canada#errors) for invalid `id`s.
+Returns one Canadian statutory holiday by integer id. Returns [a `400` response](https://github.com/pcraig3/holidays-canada#errors) for invalid `holidayId`s.
 
 <details>
 <summary>Example response</summary>
@@ -203,9 +224,9 @@ Returns one Canadian statutory holiday by integer id. Returns [a `404` response]
 
 </details>
 
-### errors
+#### errors
 
-Errors are thrown for invalid url paths or bad `id` values.
+Errors are returned for invalid url paths or bad `id` values.
 
 <details>
 <summary>Example response</summary>

--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@ Features:
 - Returns "next" holiday for each region
 - Returns holidays for years: `2018`, `2019`, `2020`, `2021`, `2022`
 
-Plus(!) check out all these goodies you get ✨ for free ✨:
+Plus(!) check out all these goodies you get for ✨ free ✨:
 
 - It’s free (✨)
 - <a href="https://twitter.com/pcraig3" target="_blank">Dedicated support channel</a>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# hols
+# Canada Holidays
 
-This is a fun little node app for Canada's statutory holidays. There's a frontend you can look at and an API you can use.
+This is a fun little [express](https://expressjs.com/) app for Canada's statutory holidays. There's a frontend you can look at and an API you can use.
 
-- The frontend is written using [htm](https://github.com/developit/htm) on the server. Very amusing.
-- The backend API is pretty bare-metal: it's using an initial SQLite migration file stored in memory and then it does "db reads" and spits out rows.
+- The frontend is using [htm](https://github.com/developit/htm) server-rendered components. Very amusing.
+- The backend API is pretty bare-metal: it's using an initial SQLite migration file stored in memory and then it does "db reads" and spits out JSON.
 
 ## Using the API
 
 Please get in touch if you are using the API, because I can probably make it work better if I have real-life use-cases.
 
 [Read the API docs](https://github.com/pcraig3/hols/blob/master/API.md).
+
+There's an OpenAPI spec at [`Canada-Holidays-API.v1.yaml`](https://github.com/pcraig3/hols/blob/master/reference/Canada-Holidays-API.v1.yaml) and a <a href="https://app.swaggerhub.com/apis/pcraig3/canada-holidays/" target="_blank">SwaggerHub</a> page where you can test the endpoints.
 
 ## Getting started
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,9 +3,6 @@
 - Add years to dates on years pages?
 - make API to return CSV format
   - page for CSV downloads
-- swagger api spec
-  - swagger ui?
-  - write about them
 - add a print button?
 - https://matthewsmith.io/blog/how-to-set-up-cache-busting-in-express
 - list of holidays
@@ -15,6 +12,7 @@
 - swagger api spec
   - add them
   - test them
+  - write about them
 - /favicon.ico less 404s
 - CORS for the API
 - server logs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,61 +8,61 @@
 
 <url>
   <loc>https://canada-holidays.ca/</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
@@ -80,151 +80,151 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
@@ -236,241 +236,241 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2018</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2019</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2021</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2022</loc>
-  <lastmod>2020-04-16T05:48:20+00:00</lastmod>
+  <lastmod>2020-04-28T06:19:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -67,9 +67,9 @@ const styles = css`
   }
 `
 
-const Details = ({ summary, id, children, ...props }) => {
+const Details = ({ summary, id, children, className, ...props }) => {
   return html`
-    <details class=${styles} id=${id}>
+    <details class=${className ? `${styles} ${className}` : styles} id=${id}>
       <summary ...${props}>
         <span ...${props}>${summary}</span>
       </summary>

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -1,34 +1,57 @@
 const { html } = require('../utils')
+const { css } = require('emotion')
 const Layout = require('../components/Layout.js')
 const Content = require('../components/Content.js')
 
-const Feedback = () =>
+const linkStyle = css`
+  text-decoration: none;
+`
+
+const API = () =>
   html`
     <${Layout} route="/api">
       <${Content}>
         <h1>Canada Holidays API</h1>
         <p>
-          <a href="/">canada-holidays.ca</a> is powered by a JSON API that returns Canada’s
-          statutory holidays, and you can use it too.${' '}
+          The ${' '}<a href="https://canada-holidays.ca/api/v1/" target="_blank"
+            >Canada Holidays API</a
+          >${' '}lists all 28 public holidays for all 13 provinces and territories in Canada,
+          including federal holidays.
         </p>
         <p>
           <span aria-hidden="true">👉</span>${' '}
-          <a href="https://canada-holidays.ca/api/v1/" target="_blank"
-            >https://canada-holidays.ca/api/v1/</a
+          <strong
+            ><a class=${linkStyle} href="https://canada-holidays.ca/api/v1/" target="_blank"
+              >https://canada-holidays.ca/api/v1/</a
+            ></strong
           >
-          ${' '}<span aria-hidden="true">👈</span>
+          ${' '}
         </p>
         <p>Features:</p>
         <ul>
           <li>Return holidays with associated regions</li>
           <li>Return regions with associated holidays</li>
-          <li>Filter by federal holidays</li>
-          <li>Filter by national holidays</li>
-          <li>Free forever</li>
-          <li>It’s pretty good</li>
+          <li>Returns federal holidays</li>
+          <li>Returns national holidays</li>
+          <li>Returns “next” holiday for each region</li>
+          <li>
+            Returns holidays for multiple years: <code>2018</code>, <code>2019</code>,${' '}
+            <code>2020</code>, <code>2021</code>, <code>2022</code>.
+          </li>
+        </ul>
+        <p>
+          Plus(!!!) check out all these goodies you get for${' '}
+          <span aria-hidden="true">✨</span> free <span aria-hidden="true">✨</span>:
+        </p>
+
+        <ul>
+          <li>It’s free (<span aria-hidden="true">✨</span>)</li>
+          <li>
+            <a href="https://twitter.com/pcraig3" target="_blank">Dedicated support channel</a>
+          </li>
           <li>Kind of bilingual (EN & FR)</li>
           <li>
-            Nearly compliant with the${' '}
+            Pretty much compliant with the${' '}
             <a
               href="https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/government-canada-standards-apis.html"
               target="_blank"
@@ -39,17 +62,36 @@ const Feedback = () =>
             <a href="https://github.com/pcraig3/hols" target="_blank">Open source</a> which is cool
             if you’re a nerd
           </li>
+          <li>
+            <a
+              href="https://github.com/pcraig3/hols/blob/master/reference/Canada-Holidays-API.v1.yaml"
+              target="_blank"
+              >Documented with an OpenAPI spec</a
+            >${' '}which is <em>even more</em> cool for <em>even nerdier</em> nerds
+          </li>
         </ul>
         <p>Definitely use it for your billions of dollars mission-critical system.</p>
 
         <h2>Documentation</h2>
         <p>
-          <a
+          There's an OpenAPI spec at${' '}<a
+            href="https://github.com/pcraig3/hols/blob/master/reference/Canada-Holidays-API.v1.yaml"
+            target="_blank"
+            ><code>Canada-Holidays-API.v1.yaml</code></a
+          >${' '}and a${' '}<a
+            href="https://app.swaggerhub.com/apis/pcraig3/canada-holidays/"
+            target="_blank"
+            >SwaggerHub</a
+          >${' '}page where you can test the endpoints.
+        </p>
+        <p>
+          Otherwise, the${' '}<a
             title="API documentation"
             href="https://github.com/pcraig3/hols/blob/master/API.md"
             target="_blank"
-            >Documentation is here</a
-          >; it’s pretty good. (see point 5 above.)
+            >documentation on GitHub</a
+          >
+          ${' '}is pretty good.
         </p>
 
         <h2>Citations</h2>
@@ -57,7 +99,7 @@ const Feedback = () =>
           Scraped the data from the Wikipedia article “<a
             href="https://en.wikipedia.org/wiki/Public_holidays_in_Canada"
             >Public holidays in Canada</a
-          >” that knows about which provinces observe which holidays and vice-versa. And${' '}
+          >” that tables out which provinces observe which holidays and vice-versa. And${' '}
           <em>then</em>${' '}I even${' '}
           <a href="https://github.com/pcraig3/hols/#citations" title="Citations" target="_blank"
             >double-checked</a
@@ -68,4 +110,4 @@ const Feedback = () =>
     <//>
   `
 
-module.exports = Feedback
+module.exports = API

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -1,10 +1,25 @@
 const { html } = require('../utils')
 const { css } = require('emotion')
+const { theme } = require('../styles')
 const Layout = require('../components/Layout.js')
 const Content = require('../components/Content.js')
+const Details = require('../components/Details.js')
 
 const linkStyle = css`
   text-decoration: none;
+`
+
+const detailsStyle = css`
+  font-size: 1em !important;
+  margin-bottom: ${theme.space.md};
+
+  ul {
+    padding-left: 25px !important;
+
+    @media (${theme.mq.md}) {
+      padding-left: 35px !important;
+    }
+  }
 `
 
 const API = () =>
@@ -39,37 +54,39 @@ const API = () =>
             <code>2020</code>, <code>2021</code>, <code>2022</code>.
           </li>
         </ul>
-        <p>
-          Plus(!!!) check out all these goodies you get for${' '}
-          <span aria-hidden="true">✨</span> free <span aria-hidden="true">✨</span>:
-        </p>
-
-        <ul>
-          <li>It’s free (<span aria-hidden="true">✨</span>)</li>
-          <li>
-            <a href="https://twitter.com/pcraig3" target="_blank">Dedicated support channel</a>
-          </li>
-          <li>Kind of bilingual (EN & FR)</li>
-          <li>
-            Pretty much compliant with the${' '}
-            <a
-              href="https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/government-canada-standards-apis.html"
-              target="_blank"
-              >Government of Canada Standards on APIs</a
-            >${' '} (heck yes <span aria-hidden="true">🤙</span>)
-          </li>
-          <li>
-            <a href="https://github.com/pcraig3/hols" target="_blank">Open source</a> which is cool
-            if you’re a nerd
-          </li>
-          <li>
-            <a
-              href="https://github.com/pcraig3/hols/blob/master/reference/Canada-Holidays-API.v1.yaml"
-              target="_blank"
-              >Documented with an OpenAPI spec</a
-            >${' '}which is <em>even more</em> cool for <em>even nerdier</em> nerds
-          </li>
-        </ul>
+        <${Details}
+          summary="Plus(!!!) check out all the goodies you get for free"
+          className=${detailsStyle}
+          data-event="true"
+          data-label="api-features"
+        >
+          <ul>
+            <li>It’s free (<span aria-hidden="true">✨</span>)</li>
+            <li>
+              <a href="https://twitter.com/pcraig3" target="_blank">Dedicated support channel</a>
+            </li>
+            <li>Kind of bilingual (EN & FR)</li>
+            <li>
+              Pretty much compliant with the${' '}
+              <a
+                href="https://www.canada.ca/en/government/system/digital-government/modern-emerging-technologies/government-canada-standards-apis.html"
+                target="_blank"
+                >Government of Canada Standards on APIs</a
+              >${' '} (heck yes <span aria-hidden="true">🤙</span>)
+            </li>
+            <li>
+              <a href="https://github.com/pcraig3/hols" target="_blank">Open source</a> which is
+              cool if you’re a nerd
+            </li>
+            <li>
+              <a
+                href="https://github.com/pcraig3/hols/blob/master/reference/Canada-Holidays-API.v1.yaml"
+                target="_blank"
+                >Documented with an OpenAPI spec</a
+              >${' '}which is <em>even more</em> cool for <em>even nerdier</em> nerds
+            </li>
+          </ul>
+        <//>
         <p>Definitely use it for your billions of dollars mission-critical system.</p>
 
         <h2>Documentation</h2>

--- a/src/styles.js
+++ b/src/styles.js
@@ -105,6 +105,10 @@ const contentPageStyles = css`
     }
   }
 
+  code {
+    font-size: 1.05em;
+  }
+
   footer {
     margin-top: calc(${theme.space.xl} + ${theme.space.xl});
   }


### PR DESCRIPTION
There are 2 places for API documentation. (3, if you count the spec). 

Updated `API.md` and `/api` so they're a lot closer, and added references to the OpenAPI spec to both, as well as to the `README`.

Also updated the sitemap to reflect some of the content has changed.