### PR TITLE
redirect yearless /ics requests to url paths containing the current year

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 
 # DONE
 
+- redirect yearless /ics url paths to the current year
 - swagger api spec
   - add them
   - test them

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -19,27 +19,14 @@ describe('Test ics responses', () => {
     db.close()
   })
 
-  describe('Test /ics response', () => {
-    test('it should return 301 with current year in domain', async () => {
-      const response = await request(app).get('/ics')
-      expect(response.statusCode).toBe(301)
-      expect(response.headers.location).toBe('/ics/2020')
-    })
-  })
-
-  describe('Test /ics/federal response', () => {
-    test('it should return 301 with current year in domain', async () => {
-      const response = await request(app).get('/ics/federal')
-      expect(response.statusCode).toBe(301)
-      expect(response.headers.location).toBe('/ics/federal/2020')
-    })
-  })
-
-  describe('Test /ics/AB response', () => {
-    test('it should return 301 with current year in domain', async () => {
-      const response = await request(app).get('/ics/AB')
-      expect(response.statusCode).toBe(301)
-      expect(response.headers.location).toBe('/ics/AB/2020')
+  const noYearURLs = ['/ics', '/ics/federal', '/ics/AB']
+  noYearURLs.map((url) => {
+    describe(`Test "${url}" response`, () => {
+      test('it should return 301 with current year in domain', async () => {
+        const response = await request(app).get(url)
+        expect(response.statusCode).toBe(301)
+        expect(response.headers.location).toBe(`${url}/2020`)
+      })
     })
   })
 

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -20,23 +20,26 @@ describe('Test ics responses', () => {
   })
 
   describe('Test /ics response', () => {
-    test('it should return 404', async () => {
+    test('it should return 301 with current year in domain', async () => {
       const response = await request(app).get('/ics')
-      expect(response.statusCode).toBe(404)
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/ics/2020')
     })
   })
 
   describe('Test /ics/federal response', () => {
-    test('it should return 404', async () => {
+    test('it should return 301 with current year in domain', async () => {
       const response = await request(app).get('/ics/federal')
-      expect(response.statusCode).toBe(404)
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/ics/federal/2020')
     })
   })
 
   describe('Test /ics/AB response', () => {
-    test('it should return 404', async () => {
+    test('it should return 301 with current year in domain', async () => {
       const response = await request(app).get('/ics/AB')
-      expect(response.statusCode).toBe(404)
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/ics/AB/2020')
     })
   })
 

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -61,6 +61,8 @@ const downloadICS = ({ req, res, modifier = null, year = getCurrentHolidayYear()
   }
 }
 
+router.get('/ics', (req, res) => res.redirect(301, `/ics/${getCurrentHolidayYear()}`))
+
 router.get(
   '/ics/:year(\\d{4})',
   param2query('year'),
@@ -74,6 +76,10 @@ router.get(
     ics.createEvents(holidays, downloadICS({ req, res, year }))
   },
 )
+
+router.get('/ics/federal', (req, res) => {
+  return res.redirect(301, `/ics/federal/${getCurrentHolidayYear()}`)
+})
 
 router.get(
   '/ics/federal/:year(\\d{4})',
@@ -90,8 +96,15 @@ router.get(
   },
 )
 
+router.get('/ics/:provinceId(\\w{2})', (req, res) => {
+  let provinceId = req.params.provinceId
+  return isProvinceId(provinceId)
+    ? res.redirect(301, `/ics/${provinceId}/${getCurrentHolidayYear()}`)
+    : res.redirect(`/province/${provinceId}`) // if bad province ID, redirect will be to a 404 page
+})
+
 router.get(
-  '/ics/:provinceId/:year(\\d{4})',
+  '/ics/:provinceId(\\w{2})/:year(\\d{4})',
   param2query('year'),
   dbmw(db, getHolidaysWithProvinces),
   (req, res) => {


### PR DESCRIPTION
noticed a few 404s show up that I can probably fix by "releasing" this amazing "feature".

bumped it up a minor version.