### PR TITLE
Change onscreen references from "PE" to "PEI"

### DIFF
--- a/src/components/ObservingProvinces.js
+++ b/src/components/ObservingProvinces.js
@@ -1,4 +1,4 @@
-const { html } = require('../utils')
+const { html, pe2pei } = require('../utils')
 
 const ObservingProvinces = ({ provinces = [], federal = false }) => {
   if (provinces.length === 13) {
@@ -47,7 +47,9 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
     return html`
       <p>
         Observed in
-        ${provinces.map((p) => html`${' '}<a href=${`/province/${p.id}`}>${p.id}</a>${','}`)}
+        ${provinces.map(
+          (p) => html`${' '}<a href=${`/province/${p.id}`}>${pe2pei(p.id)}</a>${','}`,
+        )}
         ${' '}and by${' '}<a href="/federal">federal industries</a>
       </p>
     `
@@ -58,7 +60,7 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
       Observed in
       ${provinces.map(
         (p) => html`
-          ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`}>${p.id}</a
+          ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`}>${pe2pei(p.id)}</a
           >${isLastProvince(p) ? '' : ','}
         `,
       )}

--- a/src/components/__tests__/ObservingProvinces.test.js
+++ b/src/components/__tests__/ObservingProvinces.test.js
@@ -48,7 +48,7 @@ describe('ObservingProvinces', () => {
     const provinces = getProvinces(3)
 
     const $ = renderObservingProvinces({ provinces })
-    expect($('p').text()).toEqual('Observed in PE, QC, and SK')
+    expect($('p').text()).toEqual('Observed in PEI, QC, and SK')
   })
 
   describe('with federal industries', () => {
@@ -79,7 +79,7 @@ describe('ObservingProvinces', () => {
       const provinces = getProvinces(3)
 
       const $ = renderObservingProvinces({ provinces, federal: true })
-      expect($('p').text()).toEqual('Observed in PE, QC, SK, and by federal industries')
+      expect($('p').text()).toEqual('Observed in PEI, QC, SK, and by federal industries')
     })
   })
 

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -1,5 +1,5 @@
 const { css } = require('emotion')
-const { html, getProvinceIdOrFederalString } = require('../utils')
+const { html, pe2pei, getProvinceIdOrFederalString } = require('../utils')
 const { theme, visuallyHidden, horizontalPadding, insideContainer } = require('../styles')
 const Layout = require('../components/Layout.js')
 const DateHtml = require('../components/DateHtml.js')
@@ -93,7 +93,8 @@ const createRows = (holidays, federal, isCurrentYear) => {
     let provincesHTML = holiday.provinces.map(
       (p, i) =>
         html`
-          <a href="/province/${p.id}" title="Holidays for ${p.nameEn}">${p.id}</a>${i + 1 ===
+          <a href="/province/${p.id}" title="Holidays for ${p.nameEn}">${pe2pei(p.id)}</a>${i +
+            1 ===
           holiday.provinces.length
             ? ''
             : ', '}

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -103,7 +103,7 @@ const createRows = (holidays, federal, isCurrentYear) => {
 
     if (holiday.federal) {
       provincesHTML = html`
-        <a href="/federal" title="Federal holidays">Federal</a>${provincesHTML.length
+        <a href="/federal" title="Federal holidays">Federal holiday</a>${provincesHTML.length
           ? ', '
           : ''}${provincesHTML}
       `

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -182,7 +182,9 @@ describe('Test ui responses', () => {
         expect($('title').text()).toEqual(
           'Manitoba (MB) statutory holidays in 2020 — Canada Holidays',
         )
-        expect($('meta[name="description"]').attr('content')).toMatch(/^MB’s next stat holiday is/)
+        expect($('meta[name="description"]').attr('content')).toMatch(
+          /^Manitoba’s next stat holiday is/,
+        )
         expect($('meta[name="description"]').attr('content')).toMatch(
           /See all statutory holidays in Manitoba, Canada in 2020/,
         )

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -191,6 +191,14 @@ describe('Test ui responses', () => {
       })
     })
 
+    describe('Test /province/PEI response', () => {
+      test('it should return 301', async () => {
+        const response = await request(app).get('/province/PEI')
+        expect(response.statusCode).toBe(301)
+        expect(response.headers.location).toEqual('/province/PE')
+      })
+    })
+
     describe('Test /province/:provinceId/:year responses', () => {
       test('it should return the h1, title, and meta tag for MB in 2021', async () => {
         const response = await request(app).get('/province/MB/2021')

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -70,7 +70,7 @@ router.get(
     const year = getCurrentHolidayYear()
     const { holidays, nextHoliday, nameEn: provinceName, id: provinceId } = res.locals.rows[0]
 
-    const meta = `${provinceId}’s next stat holiday is ${getMeta(
+    const meta = `${provinceName}’s next stat holiday is ${getMeta(
       nextHoliday,
     )}. See all statutory holidays in ${provinceName}, Canada in ${year}.`
 

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -62,6 +62,8 @@ router.get(
   },
 )
 
+router.get('/province/PEI', (req, res) => res.redirect(301, '/province/PE'))
+
 router.get(
   '/province/:provinceId',
   checkProvinceIdErr,

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -12,6 +12,7 @@ const {
   checkRedirectIfCurrentYear,
   param2query,
   nextHoliday,
+  pe2pei,
   getCurrentHolidayYear,
 } = require('../utils')
 const { getProvinces, getHolidaysWithProvinces, getProvincesWithHolidays } = require('../queries')
@@ -77,7 +78,9 @@ router.get(
     return res.send(
       renderPage({
         pageComponent: 'Province',
-        title: `${provinceName} (${provinceId}) statutory holidays in ${year} — Canada Holidays`,
+        title: `${provinceName} (${pe2pei(
+          provinceId,
+        )}) statutory holidays in ${year} — Canada Holidays`,
         docProps: { meta, path: req.path },
         props: {
           data: { holidays, nextHoliday, provinceName, provinceId, year },
@@ -103,7 +106,9 @@ router.get(
     return res.send(
       renderPage({
         pageComponent: 'Province',
-        title: `${provinceName} (${provinceId}) statutory holidays in ${year} — Canada Holidays`,
+        title: `${provinceName} (${pe2pei(
+          provinceId,
+        )}) statutory holidays in ${year} — Canada Holidays`,
         docProps: { meta, path: req.path },
         props: {
           data: {

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -4,6 +4,7 @@ const {
   upcomingHolidays,
   getCurrentHolidayYear,
   isProvinceId,
+  pe2pei,
   getProvinceIdOrFederalString,
 } = require('../index')
 const holidays = require('./data.skip')
@@ -91,7 +92,7 @@ describe('Test getCurrentHolidayYear', () => {
     global.Date = RealDate
   })
 
-  const mockDate = dateString => {
+  const mockDate = (dateString) => {
     global.Date.now = () => new Date(dateString)
   }
 
@@ -132,6 +133,16 @@ describe('Test isProvinceId', () => {
 
   test('returns false for a non-province id', () => {
     expect(isProvinceId('hawaii')).toBe(false)
+  })
+})
+
+describe('Test pe2pei', () => {
+  test('returns "PEI" for "PE"', () => {
+    expect(pe2pei('PE')).toBe('PEI')
+  })
+
+  test('returns original string for anything else', () => {
+    expect(pe2pei('ON')).toBe('ON')
   })
 })
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -218,6 +218,8 @@ const getCurrentHolidayYear = () => {
   return d.getUTCFullYear()
 }
 
+const pe2pei = (provinceId) => (provinceId === 'PE' ? 'PEI' : provinceId)
+
 /**
  * This function returns a provinceId if one is passed in, the string 'federal', if federal exists and is truthy,
  * or undefined, if neither are there.
@@ -251,5 +253,6 @@ module.exports = {
   nextHoliday,
   upcomingHolidays,
   getCurrentHolidayYear,
+  pe2pei,
   getProvinceIdOrFederalString,
 }


### PR DESCRIPTION
i get the algorithmic purity of 2 letter codes, but seriously, it's self-evident that PEI should be referred to as "PEI" rather than "PE", which personally I had never heard before starting this stupid website.

