### PR TITLE
Add max-age headers to static assets and use app version number as query parameter for cache busting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 
 # DONE
 
+- cache static files for longer than not at all
 - PEI, let's call it "PEI" on the screen at least
   - on the meta tag
   - on the holiday listing page

--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,12 @@
 - make API to return CSV format
   - page for CSV downloads
 - add a print button?
-- https://matthewsmith.io/blog/how-to-set-up-cache-busting-in-express
 - list of holidays
 
 # DONE
 
 - cache static files for longer than not at all
+  - set up cache busting in express
 - PEI, let's call it "PEI" on the screen at least
   - on the meta tag
   - on the holiday listing page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -216,7 +216,7 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
           </div>
         </form>
       </div>
-      <script src="/js/picker.js"></script>
+      <script src="/js/picker.js?v=${process.env.npm_package_version}"></script>
     </div>
   `
 }

--- a/src/headStyles.js
+++ b/src/headStyles.js
@@ -30,11 +30,11 @@ module.exports = {
     font-display: swap;
     src: url('/fonts/gothic-a1-v8-latin-300.eot'); /* IE9 Compat Modes */
     src: local('Gothic A1 Light'), local('GothicA1-Light'),
-         url('/fonts/gothic-a1-v8-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('/fonts/gothic-a1-v8-latin-300.woff2') format('woff2'), /* Super Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-300.woff') format('woff'), /* Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-300.ttf') format('truetype'), /* Safari, Android, iOS */
-         url('/fonts/gothic-a1-v8-latin-300.svg#GothicA1') format('svg'); /* Legacy iOS */
+         url('/fonts/gothic-a1-v8-latin-300.eot?#iefix&v=${process.env.npm_package_version}') format('embedded-opentype'), /* IE6-IE8 */
+         url('/fonts/gothic-a1-v8-latin-300.woff2?v=${process.env.npm_package_version}') format('woff2'), /* Super Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-300.woff?v=${process.env.npm_package_version}') format('woff'), /* Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-300.ttf?v=${process.env.npm_package_version}') format('truetype'), /* Safari, Android, iOS */
+         url('/fonts/gothic-a1-v8-latin-300.svg#GothicA1?v=${process.env.npm_package_version}') format('svg'); /* Legacy iOS */
   }
   /* gothic-a1-regular - latin */
   @font-face {
@@ -44,11 +44,11 @@ module.exports = {
     font-display: swap;
     src: url('/fonts/gothic-a1-v8-latin-regular.eot'); /* IE9 Compat Modes */
     src: local('Gothic A1 Regular'), local('GothicA1-Regular'),
-         url('/fonts/gothic-a1-v8-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('/fonts/gothic-a1-v8-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-regular.woff') format('woff'), /* Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
-         url('/fonts/gothic-a1-v8-latin-regular.svg#GothicA1') format('svg'); /* Legacy iOS */
+         url('/fonts/gothic-a1-v8-latin-regular.eot?#iefix&v=${process.env.npm_package_version}') format('embedded-opentype'), /* IE6-IE8 */
+         url('/fonts/gothic-a1-v8-latin-regular.woff2?v=${process.env.npm_package_version}') format('woff2'), /* Super Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-regular.woff?v=${process.env.npm_package_version}') format('woff'), /* Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-regular.ttf?v=${process.env.npm_package_version}') format('truetype'), /* Safari, Android, iOS */
+         url('/fonts/gothic-a1-v8-latin-regular.svg#GothicA1?v=${process.env.npm_package_version}') format('svg'); /* Legacy iOS */
   }
   /* gothic-a1-500 - latin */
   @font-face {
@@ -58,11 +58,11 @@ module.exports = {
     font-display: swap;
     src: url('/fonts/gothic-a1-v8-latin-500.eot'); /* IE9 Compat Modes */
     src: local('Gothic A1 Medium'), local('GothicA1-Medium'),
-         url('/fonts/gothic-a1-v8-latin-500.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('/fonts/gothic-a1-v8-latin-500.woff2') format('woff2'), /* Super Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-500.woff') format('woff'), /* Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-500.ttf') format('truetype'), /* Safari, Android, iOS */
-         url('/fonts/gothic-a1-v8-latin-500.svg#GothicA1') format('svg'); /* Legacy iOS */
+         url('/fonts/gothic-a1-v8-latin-500.eot?#iefix&v=${process.env.npm_package_version}') format('embedded-opentype'), /* IE6-IE8 */
+         url('/fonts/gothic-a1-v8-latin-500.woff2?v=${process.env.npm_package_version}') format('woff2'), /* Super Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-500.woff?v=${process.env.npm_package_version}') format('woff'), /* Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-500.ttf?v=${process.env.npm_package_version}') format('truetype'), /* Safari, Android, iOS */
+         url('/fonts/gothic-a1-v8-latin-500.svg#GothicA1?v=${process.env.npm_package_version}') format('svg'); /* Legacy iOS */
   }
   /* gothic-a1-600 - latin */
   @font-face {
@@ -72,11 +72,11 @@ module.exports = {
     font-display: swap;
     src: url('/fonts/gothic-a1-v8-latin-600.eot'); /* IE9 Compat Modes */
     src: local('Gothic A1 SemiBold'), local('GothicA1-SemiBold'),
-         url('/fonts/gothic-a1-v8-latin-600.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('/fonts/gothic-a1-v8-latin-600.woff2') format('woff2'), /* Super Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-600.woff') format('woff'), /* Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-600.ttf') format('truetype'), /* Safari, Android, iOS */
-         url('/fonts/gothic-a1-v8-latin-600.svg#GothicA1') format('svg'); /* Legacy iOS */
+         url('/fonts/gothic-a1-v8-latin-600.eot?#iefix&v=${process.env.npm_package_version}') format('embedded-opentype'), /* IE6-IE8 */
+         url('/fonts/gothic-a1-v8-latin-600.woff2?v=${process.env.npm_package_version}') format('woff2'), /* Super Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-600.woff?v=${process.env.npm_package_version}') format('woff'), /* Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-600.ttf?v=${process.env.npm_package_version}') format('truetype'), /* Safari, Android, iOS */
+         url('/fonts/gothic-a1-v8-latin-600.svg#GothicA1?v=${process.env.npm_package_version}') format('svg'); /* Legacy iOS */
   }
   /* gothic-a1-700 - latin */
   @font-face {
@@ -86,11 +86,11 @@ module.exports = {
     font-display: swap;
     src: url('/fonts/gothic-a1-v8-latin-700.eot'); /* IE9 Compat Modes */
     src: local('Gothic A1 Bold'), local('GothicA1-Bold'),
-         url('/fonts/gothic-a1-v8-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-         url('/fonts/gothic-a1-v8-latin-700.woff2') format('woff2'), /* Super Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-700.woff') format('woff'), /* Modern Browsers */
-         url('/fonts/gothic-a1-v8-latin-700.ttf') format('truetype'), /* Safari, Android, iOS */
-         url('/fonts/gothic-a1-v8-latin-700.svg#GothicA1') format('svg'); /* Legacy iOS */
+         url('/fonts/gothic-a1-v8-latin-700.eot?#iefix&v=${process.env.npm_package_version}') format('embedded-opentype'), /* IE6-IE8 */
+         url('/fonts/gothic-a1-v8-latin-700.woff2?v=${process.env.npm_package_version}') format('woff2'), /* Super Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-700.woff?v=${process.env.npm_package_version}') format('woff'), /* Modern Browsers */
+         url('/fonts/gothic-a1-v8-latin-700.ttf?v=${process.env.npm_package_version}') format('truetype'), /* Safari, Android, iOS */
+         url('/fonts/gothic-a1-v8-latin-700.svg#GothicA1?v=${process.env.npm_package_version}') format('svg'); /* Legacy iOS */
   }`,
   printStyles: `
   @media print {

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -96,8 +96,8 @@ const document = ({ title, content, docProps: { meta, path } }) => {
       </head>
       <body id="body">
         ${content}
-        <script src="/js/sweet-scroll.min.js"></script>
-        <script src="/js/script.js"></script>
+        <script src="/js/sweet-scroll.min.js?v=${process.env.npm_package_version}"></script>
+        <script src="/js/script.js?v=${process.env.npm_package_version}"></script>
       </body>
     </html>
   `

--- a/src/server.js
+++ b/src/server.js
@@ -16,7 +16,7 @@ app
   // both of these are needed to parse post request params
   .use(express.urlencoded({ extended: true }))
   .use(express.json())
-  .use(express.static('public', { maxage: '3d' }))
+  .use(express.static('public', { maxage: process.env.NODE_ENV === 'production' ? '3d' : '0' }))
   .use(compression())
 
 // if NODE_ENV does not equal 'test', add a request logger

--- a/src/server.js
+++ b/src/server.js
@@ -16,7 +16,7 @@ app
   // both of these are needed to parse post request params
   .use(express.urlencoded({ extended: true }))
   .use(express.json())
-  .use(express.static('public'))
+  .use(express.static('public', { maxage: '3d' }))
   .use(compression())
 
 // if NODE_ENV does not equal 'test', add a request logger


### PR DESCRIPTION
## set up cache busting based on app versions


noticed that the fonts were reloading on every pageload which is BAD.
but then the problem is how do you make sure the cache is stale when you want it be to.

easy enough: use the version number in the url as a query param for attachments.

also only set max-age header in prod. Otherwise we will be caching development files unintentionally.

Sources:
- https://stackoverflow.com/a/22339262
- http://ankitjain.info/ankit/2013/12/05/cache-busting-nodejs-express-jade/

