### PR TITLE
Christmas later

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_Store
 /*.env
 /coverage
+.vscode

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,7 @@
 # TODO
 
+- New key "observedDate"
+- "date" is the date
 - add next/previous links at the bottom
 - add sources
 - figure out about optional holidays
@@ -12,6 +14,7 @@
 
 # DONE
 
+- Christmas is after Saturday
 - cache static files for longer than not at all
   - set up cache busting in express
 - PEI, let's call it "PEI" on the screen at least

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/dates/__tests__/index.test.js
+++ b/src/dates/__tests__/index.test.js
@@ -25,7 +25,7 @@ describe('Test getISODate', () => {
       { str: 'December 26', iso: '2019-12-26' },
     ]
 
-    days2019.map(day => {
+    days2019.map((day) => {
       test(`returns correct 2019 ISO date string for: "${day.str}"`, () => {
         expect(getISODate(day.str, 2019)).toEqual(day.iso)
       })
@@ -56,7 +56,7 @@ describe('Test getISODate', () => {
       { str: 'December 26', iso: '2020-12-28' },
     ]
 
-    days2020.map(day => {
+    days2020.map((day) => {
       test(`returns correct 2020 ISO date string for: "${day.str}"`, () => {
         expect(getISODate(day.str, 2020)).toEqual(day.iso)
       })
@@ -87,11 +87,11 @@ describe('Test getISODate', () => {
       { str: 'First Monday in September', iso: '2021-09-06' },
       { str: 'Second Monday in October', iso: '2021-10-11' },
       { str: 'November 11', iso: '2021-11-11' },
-      { str: 'December 25', iso: '2021-12-24' },
-      { str: 'December 26', iso: '2021-12-27' },
+      { str: 'December 25', iso: '2021-12-27' },
+      { str: 'December 26', iso: '2021-12-28' },
     ]
 
-    days2020.map(day => {
+    days2020.map((day) => {
       test(`returns correct 2021 ISO date string for: "${day.str}"`, () => {
         expect(getISODate(day.str, 2021)).toEqual(day.iso)
       })

--- a/src/dates/index.js
+++ b/src/dates/index.js
@@ -13,6 +13,10 @@ const _getISODayInt = (weekday) => {
     return 1
   }
 
+  if (weekday === 'Tuesday') {
+    return 2
+  }
+
   if (weekday === 'Friday') {
     return 5
   }
@@ -92,9 +96,9 @@ const getISODate = (dateString, year = new Date(Date.now()).getUTCFullYear()) =>
     date = Sugar.Date.create(dateString)
   }
 
-  // If Christmas is on a Saturday, move to Friday
-  if ([6].includes(getISODay(date)) && /December 25/i.test(dateString)) {
-    date = _parseRelativeDates(`Friday before ${dateString}`)
+  // If Boxing Day is on a Sunday, move to Tuesday (Christmas will be Monday)
+  if ([7].includes(getISODay(date)) && /December 26/i.test(dateString)) {
+    date = _parseRelativeDates(`Tuesday after ${dateString}`)
   }
 
   // If it lands on a Saturday or Sunday (and not National Aboriginal Day) move to Monday


### PR DESCRIPTION
for some reason, I thought that if Christmas was Saturday and
Boxing Day was Sunday, the Friday and Monday were off.

Apparently not:
- http://psacunion.ca/sites/psac/files/attachments/pdfs/psac-afpc-2020-calendar-gov.pdf