### PR TITLE
Observed date key

### DIFF
--- a/API.md
+++ b/API.md
@@ -108,7 +108,8 @@ Returns a list of provinces and territories in Canada. Each province or territor
           "date": "2019-01-01",
           "nameEn": "New Year’s Day",
           "nameFr": "Jour de l’An",
-          "federal": 1
+          "federal": 1,
+          "observedDate": "2019-01-01"
         },
         ...
       ],
@@ -117,7 +118,8 @@ Returns a list of provinces and territories in Canada. Each province or territor
         "date": "2019-02-18",
         "nameEn": "Family Day",
         "nameFr": "Fête de la famille",
-        "federal": 0
+        "federal": 0,
+        "observedDate": "2019-02-18"
       }
     },
     ...
@@ -146,7 +148,8 @@ Returns one province or territory in Canada by [two-letter postal abbreviations]
         "date": "2019-01-01",
         "nameEn": "New Year’s Day",
         "nameFr": "Jour de l’An",
-        "federal": 1
+        "federal": 1,
+        "observedDate": "2019-01-01"
       },
       ...
     ],
@@ -155,7 +158,8 @@ Returns one province or territory in Canada by [two-letter postal abbreviations]
       "date": "2019-02-18",
       "nameEn": "Family Day",
       "nameFr": "Fête de la famille",
-      "federal": 0
+      "federal": 0,
+      "observedDate": "2019-02-18"
     }
   }
 }
@@ -179,6 +183,7 @@ Returns a list of Canadian public holidays. Each holiday lists the regions that 
       "nameEn": "New Year’s Day",
       "nameFr": "Jour de l’An",
       "federal": 1,
+      "observedDate": "2019-01-01",
       "provinces": [
         {
           "id": "AB",
@@ -210,6 +215,7 @@ Returns one Canadian statutory holiday by integer id. Returns [a `400` response]
     "nameEn": "New Year’s Day",
     "nameFr": "Jour de l’An",
     "federal": 1,
+    "observedDate": "2019-01-01",
     "provinces": [
       {
         "id": "AB",

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 # TODO
 
-- New key "observedDate"
-- "date" is the date
 - add next/previous links at the bottom
 - add sources
 - figure out about optional holidays
@@ -14,6 +12,9 @@
 
 # DONE
 
+- New key "observedDate"
+  - update Swagger
+- "date" is the literal date
 - Christmas is after Saturday
 - cache static files for longer than not at all
   - set up cache busting in express

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -96,7 +96,7 @@ paths:
                   value:
                     holidays:
                       - id: 1
-                        date: '2020-01-01'
+                        observedDate: '2020-01-01'
                         nameEn: New Year’s Day
                         nameFr: Jour de l’An
                         federal: 1
@@ -141,7 +141,7 @@ paths:
                             nameEn: Yukon
                             nameFr: Yukon
                       - id: 2
-                        date: '2020-02-17'
+                        observedDate: '2020-02-17'
                         nameEn: Louis Riel Day
                         nameFr: Journée Louis Riel
                         federal: 0
@@ -201,18 +201,18 @@ paths:
                         nameFr: Alberta
                         holidays:
                           - id: 1
-                            date: '2020-01-01'
+                            observedDate: '2020-01-01'
                             nameEn: New Year’s Day
                             nameFr: Jour de l’An
                             federal: 1
                           - id: 4
-                            date: '2020-02-17'
+                            observedDate: '2020-02-17'
                             nameEn: Family Day
                             nameFr: Fête de la famille
                             federal: 0
                         nextHoliday:
                           id: 11
-                          date: '2020-05-18'
+                          observedDate: '2020-05-18'
                           nameEn: Victoria Day
                           nameFr: Fête de la Reine
                           federal: 1
@@ -221,18 +221,18 @@ paths:
                         nameFr: Colombie-Britannique
                         holidays:
                           - id: 1
-                            date: '2020-01-01'
+                            observedDate: '2020-01-01'
                             nameEn: New Year’s Day
                             nameFr: Jour de l’An
                             federal: 1
                           - id: 4
-                            date: '2020-02-17'
+                            observedDate: '2020-02-17'
                             nameEn: Family Day
                             nameFr: Fête de la famille
                             federal: 0
                         nextHoliday:
                           id: 11
-                          date: '2020-05-18'
+                          observedDate: '2020-05-18'
                           nameEn: Victoria Day
                           nameFr: Fête de la Reine
                           federal: 1
@@ -271,18 +271,18 @@ paths:
                       nameFr: Manitoba
                       holidays:
                         - id: 1
-                          date: '2020-01-01'
+                          observedDate: '2020-01-01'
                           nameEn: New Year’s Day
                           nameFr: Jour de l’An
                           federal: 1
                         - id: 2
-                          date: '2020-02-17'
+                          observedDate: '2020-02-17'
                           nameEn: Louis Riel Day
                           nameFr: Journée Louis Riel
                           federal: 0
                       nextHoliday:
                         id: 11
-                        date: '2020-05-18'
+                        observedDate: '2020-05-18'
                         nameEn: Victoria Day
                         nameFr: Fête de la Reine
                         federal: 1
@@ -367,7 +367,7 @@ paths:
                   value:
                     holiday:
                       id: 2
-                      date: '2020-02-17'
+                      observedDate: '2020-02-17'
                       nameEn: Louis Riel Day
                       nameFr: Journée Louis Riel
                       federal: 0
@@ -414,7 +414,7 @@ components:
       x-examples:
         /holidays/2:
           id: 2
-          date: '2020-02-17'
+          observedDate: '2020-02-17'
           nameEn: Louis Riel Day
           nameFr: Journée Louis Riel
           federal: 0
@@ -429,7 +429,7 @@ components:
           example: 2
           minimum: 1
           maximum: 28
-        date:
+        observedDate:
           type: string
           description: ISO date
           format: date
@@ -463,48 +463,48 @@ components:
           nameFr: Manitoba
           holidays:
             - id: 1
-              date: '2020-01-01'
+              observedDate: '2020-01-01'
               nameEn: New Year’s Day
               nameFr: Jour de l’An
               federal: 1
             - id: 2
-              date: '2020-02-17'
+              observedDate: '2020-02-17'
               nameEn: Louis Riel Day
               nameFr: Journée Louis Riel
               federal: 0
             - id: 7
-              date: '2020-04-10'
+              observedDate: '2020-04-10'
               nameEn: Good Friday
               nameFr: Vendredi saint
               federal: 1
             - id: 11
-              date: '2020-05-18'
+              observedDate: '2020-05-18'
               nameEn: Victoria Day
               nameFr: Fête de la Reine
               federal: 1
             - id: 15
-              date: '2020-07-01'
+              observedDate: '2020-07-01'
               nameEn: Canada Day
               nameFr: Fête du Canada
               federal: 1
             - id: 24
-              date: '2020-09-07'
+              observedDate: '2020-09-07'
               nameEn: Labour Day
               nameFr: Fête du travail
               federal: 1
             - id: 25
-              date: '2020-10-12'
+              observedDate: '2020-10-12'
               nameEn: Thanksgiving
               nameFr: Action de grâce
               federal: 1
             - id: 27
-              date: '2020-12-25'
+              observedDate: '2020-12-25'
               nameEn: Christmas Day
               nameFr: Noël
               federal: 1
           nextHoliday:
             id: 11
-            date: '2020-05-18'
+            observedDate: '2020-05-18'
             nameEn: Victoria Day
             nameFr: Fête de la Reine
             federal: 1

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 info:
   title: Canada Holidays API
-  version: 1.0.3
+  version: 1.1.0
   description: 'This API lists all 28 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
-    url: 'https://canada-holidays.ca/feedback'
+    url: 'https://canada-holidays.ca/api'
     email: paul@pcraig3.ca
   license:
     name: MIT
@@ -96,10 +96,11 @@ paths:
                   value:
                     holidays:
                       - id: 1
-                        observedDate: '2020-01-01'
+                        date: '2020-01-01'
                         nameEn: New Year’s Day
                         nameFr: Jour de l’An
                         federal: 1
+                        observedDate: '2020-01-01'
                         provinces:
                           - id: AB
                             nameEn: Alberta
@@ -141,10 +142,11 @@ paths:
                             nameEn: Yukon
                             nameFr: Yukon
                       - id: 2
-                        observedDate: '2020-02-17'
+                        date: '2020-02-17'
                         nameEn: Louis Riel Day
                         nameFr: Journée Louis Riel
                         federal: 0
+                        observedDate: '2020-02-17'
                         provinces:
                           - id: MB
                             nameEn: Manitoba
@@ -201,41 +203,47 @@ paths:
                         nameFr: Alberta
                         holidays:
                           - id: 1
-                            observedDate: '2020-01-01'
+                            date: '2020-01-01'
                             nameEn: New Year’s Day
                             nameFr: Jour de l’An
                             federal: 1
+                            observedDate: '2020-01-01'
                           - id: 4
-                            observedDate: '2020-02-17'
+                            date: '2020-02-17'
                             nameEn: Family Day
                             nameFr: Fête de la famille
                             federal: 0
+                            observedDate: '2020-02-17'
                         nextHoliday:
                           id: 11
-                          observedDate: '2020-05-18'
+                          date: '2020-05-18'
                           nameEn: Victoria Day
                           nameFr: Fête de la Reine
                           federal: 1
+                          observedDate: '2020-05-18'
                       - id: BC
                         nameEn: British Columbia
                         nameFr: Colombie-Britannique
                         holidays:
                           - id: 1
-                            observedDate: '2020-01-01'
+                            date: '2020-01-01'
                             nameEn: New Year’s Day
                             nameFr: Jour de l’An
                             federal: 1
+                            observedDate: '2020-01-01'
                           - id: 4
-                            observedDate: '2020-02-17'
+                            date: '2020-02-17'
                             nameEn: Family Day
                             nameFr: Fête de la famille
                             federal: 0
+                            observedDate: '2020-02-17'
                         nextHoliday:
                           id: 11
-                          observedDate: '2020-05-18'
+                          date: '2020-05-18'
                           nameEn: Victoria Day
                           nameFr: Fête de la Reine
                           federal: 1
+                          observedDate: '2020-05-18'
       operationId: Provinces
       parameters:
         - schema:
@@ -271,21 +279,24 @@ paths:
                       nameFr: Manitoba
                       holidays:
                         - id: 1
-                          observedDate: '2020-01-01'
+                          date: '2020-01-01'
                           nameEn: New Year’s Day
                           nameFr: Jour de l’An
                           federal: 1
+                          observedDate: '2020-01-01'
                         - id: 2
-                          observedDate: '2020-02-17'
+                          date: '2020-02-17'
                           nameEn: Louis Riel Day
                           nameFr: Journée Louis Riel
                           federal: 0
+                          observedDate: '2020-02-17'
                       nextHoliday:
-                        id: 11
-                        observedDate: '2020-05-18'
-                        nameEn: Victoria Day
-                        nameFr: Fête de la Reine
+                        id: 15
+                        date: '2020-07-01'
+                        nameEn: Canada Day
+                        nameFr: Fête du Canada
                         federal: 1
+                        observedDate: '2020-07-01'
         '400':
           description: Bad Request
           content:
@@ -366,15 +377,19 @@ paths:
                 /holidays/2:
                   value:
                     holiday:
-                      id: 2
-                      observedDate: '2020-02-17'
-                      nameEn: Louis Riel Day
-                      nameFr: Journée Louis Riel
-                      federal: 0
+                      id: 28
+                      date: '2020-12-26'
+                      nameEn: Boxing Day
+                      nameFr: Lendemain de Noël
+                      federal: 1
+                      observedDate: '2020-12-28'
                       provinces:
-                        - id: MB
-                          nameEn: Manitoba
-                          nameFr: Manitoba
+                        - id: NL
+                          nameEn: Newfoundland and Labrador
+                          nameFr: Terre-Neuve-et-Labrador
+                        - id: 'ON'
+                          nameEn: Ontario
+                          nameFr: Ontario
         '400':
           description: Bad Request
           content:
@@ -410,18 +425,22 @@ components:
     Holiday:
       title: Holiday
       type: object
-      description: 'A Canadian holiday. Includes a name, date, and a list of regions that observe this holiday.'
+      description: 'A Canadian holiday. Includes a name, the literal date of the holiday, the observed date of the holiday (ie, accommodating for weekends), and a list of regions that observe this holiday.'
       x-examples:
         /holidays/2:
-          id: 2
-          observedDate: '2020-02-17'
-          nameEn: Louis Riel Day
-          nameFr: Journée Louis Riel
-          federal: 0
+          id: 28
+          date: '2020-12-26'
+          nameEn: Boxing Day
+          nameFr: Lendemain de Noël
+          federal: 1
+          observedDate: '2020-12-28'
           provinces:
-            - id: MB
-              nameEn: Manitoba
-              nameFr: Manitoba
+            - id: NL
+              nameEn: Newfoundland and Labrador
+              nameFr: Terre-Neuve-et-Labrador
+            - id: 'ON'
+              nameEn: Ontario
+              nameFr: Ontario
       properties:
         id:
           type: integer
@@ -429,11 +448,11 @@ components:
           example: 2
           minimum: 1
           maximum: 28
-        observedDate:
+        date:
           type: string
-          description: ISO date
+          description: 'ISO date: the literal date of the holiday'
           format: date
-          example: '2020-02-17'
+          example: '2020-12-26'
         nameEn:
           type: string
           description: English name
@@ -449,6 +468,11 @@ components:
             - 1
             - 0
           format: binary
+        observedDate:
+          type: string
+          description: 'ISO date: when this holiday is observed'
+          format: date
+          example: '2020-12-28'
         provinces:
           type: array
           items:
@@ -458,56 +482,66 @@ components:
       type: object
       x-examples:
         /provinces/MB:
-          id: MB
-          nameEn: Manitoba
-          nameFr: Manitoba
-          holidays:
-            - id: 1
-              observedDate: '2020-01-01'
-              nameEn: New Year’s Day
-              nameFr: Jour de l’An
-              federal: 1
-            - id: 2
-              observedDate: '2020-02-17'
-              nameEn: Louis Riel Day
-              nameFr: Journée Louis Riel
-              federal: 0
-            - id: 7
-              observedDate: '2020-04-10'
-              nameEn: Good Friday
-              nameFr: Vendredi saint
-              federal: 1
-            - id: 11
-              observedDate: '2020-05-18'
-              nameEn: Victoria Day
-              nameFr: Fête de la Reine
-              federal: 1
-            - id: 15
-              observedDate: '2020-07-01'
+          province:
+            id: MB
+            nameEn: Manitoba
+            nameFr: Manitoba
+            holidays:
+              - id: 1
+                date: '2020-01-01'
+                nameEn: New Year’s Day
+                nameFr: Jour de l’An
+                federal: 1
+                observedDate: '2020-01-01'
+              - id: 2
+                date: '2020-02-17'
+                nameEn: Louis Riel Day
+                nameFr: Journée Louis Riel
+                federal: 0
+                observedDate: '2020-02-17'
+              - id: 7
+                date: '2020-04-10'
+                nameEn: Good Friday
+                nameFr: Vendredi saint
+                federal: 1
+                observedDate: '2020-04-10'
+              - id: 11
+                date: '2020-05-18'
+                nameEn: Victoria Day
+                nameFr: Fête de la Reine
+                federal: 1
+                observedDate: '2020-05-18'
+              - id: 15
+                date: '2020-07-01'
+                nameEn: Canada Day
+                nameFr: Fête du Canada
+                federal: 1
+                observedDate: '2020-07-01'
+              - id: 24
+                date: '2020-09-07'
+                nameEn: Labour Day
+                nameFr: Fête du travail
+                federal: 1
+                observedDate: '2020-09-07'
+              - id: 25
+                date: '2020-10-12'
+                nameEn: Thanksgiving
+                nameFr: Action de grâce
+                federal: 1
+                observedDate: '2020-10-12'
+              - id: 27
+                date: '2020-12-25'
+                nameEn: Christmas Day
+                nameFr: Noël
+                federal: 1
+                observedDate: '2020-12-25'
+            nextHoliday:
+              id: 15
+              date: '2020-07-01'
               nameEn: Canada Day
               nameFr: Fête du Canada
               federal: 1
-            - id: 24
-              observedDate: '2020-09-07'
-              nameEn: Labour Day
-              nameFr: Fête du travail
-              federal: 1
-            - id: 25
-              observedDate: '2020-10-12'
-              nameEn: Thanksgiving
-              nameFr: Action de grâce
-              federal: 1
-            - id: 27
-              observedDate: '2020-12-25'
-              nameEn: Christmas Day
-              nameFr: Noël
-              federal: 1
-          nextHoliday:
-            id: 11
-            observedDate: '2020-05-18'
-            nameEn: Victoria Day
-            nameFr: Fête de la Reine
-            federal: 1
+              observedDate: '2020-07-01'
       description: 'A Canadian province or territory '
       properties:
         id:
@@ -549,7 +583,7 @@ components:
         /holidays/100:
           error:
             status: 400
-            message: 'Error: request.params.holidayId should be <= 28'
+            message: 'Bad Request: request.params.holidayId should be <= 28'
             timestamp: '2020-04-28T03:59:12.427Z'
       properties:
         status:

--- a/src/components/NextHoliday.js
+++ b/src/components/NextHoliday.js
@@ -10,7 +10,7 @@ const NextHoliday = ({ nextHoliday, provinceName = 'Canada', federal }) => {
         ${' '}next${' '}${federal && 'federal '}<span class=${visuallyHidden}>statutory </span
         >holiday is
       </div>
-      <div class="h1--lg"><${DateHtml} dateString=${nextHoliday.date} //></div>
+      <div class="h1--lg"><${DateHtml} dateString=${nextHoliday.observedDate} //></div>
       <div class="h1--md">${nextHoliday.nameEn.replace(/ /g, '\u00a0')}</div>
     </h1>
   `

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -94,7 +94,7 @@ const renderNextHolidayTitle = ({ nextHoliday, provinceName, federal }) => {
   ${provinceName == 'Canada' && !federal
     ? html`<${ObservingProvinces} provinces=${nextHoliday.provinces} federal=${nextHoliday.federal}
       //>`
-    : html`<p>${relativeDate(nextHoliday.date)}</p>`}`
+    : html`<p>${relativeDate(nextHoliday.observedDate)}</p>`}`
 }
 
 const renderYearPageTitle = ({ provinceName, provinceId, federal, year }) => {

--- a/src/components/__tests__/NextHoliday.test.js
+++ b/src/components/__tests__/NextHoliday.test.js
@@ -11,7 +11,7 @@ const renderNextHoliday = (props) => {
 const getNextHoliday = ({ federal } = {}) => {
   return {
     id: 20,
-    date: '2019-08-16',
+    observedDate: '2019-08-16',
     nameEn: 'Gold Cup Parade Day',
     federal: federal ? 1 : 0,
     provinces: [{ id: 'PE', nameEn: 'Prince Edward Island' }],

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -15,7 +15,7 @@ const getProvince = () => {
 const getNextHoliday = ({ federal } = {}) => {
   return {
     id: 20,
-    date: '2019-08-16',
+    observedDate: '2019-08-16',
     nameEn: 'Gold Cup Parade Day',
     federal: federal ? 1 : 0,
     provinces: [getProvince()],

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -116,7 +116,7 @@ const createRows = (holidays, federal, isCurrentYear) => {
 
   return holidays.map((holiday) => {
     const row = {
-      key: html` <${DateHtml} dateString=${holiday.date} weekday=${true} //> `,
+      key: html` <${DateHtml} dateString=${holiday.observedDate} weekday=${true} //> `,
       value: holiday.nameEn,
       className: '',
     }
@@ -126,14 +126,14 @@ const createRows = (holidays, federal, isCurrentYear) => {
     }
 
     if (isCurrentYear) {
-      row.className = holiday.date < today ? 'past' : 'upcoming'
+      row.className = holiday.observedDate < today ? 'past' : 'upcoming'
     }
 
-    if (previousDate === holiday.date) {
+    if (previousDate === holiday.observedDate) {
       row.className += ' repeatDate'
     }
 
-    previousDate = holiday.date
+    previousDate = holiday.observedDate
     return row
   })
 }

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -11,7 +11,7 @@ const getProvince = () => {
 const getNextHoliday = () => {
   return {
     id: 20,
-    date: '2019-08-16',
+    observedDate: '2019-08-16',
     nameEn: 'Gold Cup Parade Day',
     federal: 0,
     provinces: [getProvince()],

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,5 +1,5 @@
 const { array2Obj } = require('../utils')
-const { getObservedDate } = require('../dates')
+const { getObservedDate, getLiteralDate } = require('../dates')
 
 const _getProvinces = async (db) => await db.all('SELECT * FROM Province ORDER BY id ASC;')
 
@@ -54,8 +54,7 @@ const getHolidays = async (db, { holidayId, federal, year }) => {
 
   return holidays.map((holiday) => {
     const dateString = holiday.date
-    delete holiday.date
-    // holiday.date = getObservedDate(dateString, year)
+    holiday.date = getLiteralDate(dateString, year)
     holiday.observedDate = getObservedDate(dateString, year)
     return holiday
   })

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -53,7 +53,10 @@ const getHolidays = async (db, { holidayId, federal, year }) => {
   }
 
   return holidays.map((holiday) => {
-    holiday.date = getObservedDate(holiday.date, year)
+    const dateString = holiday.date
+    delete holiday.date
+    // holiday.date = getObservedDate(dateString, year)
+    holiday.observedDate = getObservedDate(dateString, year)
     return holiday
   })
 }
@@ -67,7 +70,7 @@ const getNextHoliday = (provinces) => {
   provinces.map((province) => {
     province.nextHoliday = province.holidays.find((holiday) => {
       // compare iso strings: eg, "2019-09-04" >= "2019-08-04"
-      return holiday.date >= new Date(Date.now()).toISOString().substring(0, 10)
+      return holiday.observedDate >= new Date(Date.now()).toISOString().substring(0, 10)
     })
   })
 }

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -40,7 +40,7 @@ describe('Test /api responses', () => {
       {},
       {
         id: expect.any(Number),
-        date: expect.any(String),
+        observedDate: expect.any(String),
         nameEn: expect.any(String),
         nameFr: expect.any(String),
         federal: expect.any(Number),
@@ -251,7 +251,7 @@ describe('Test /api responses', () => {
           let { holidays } = JSON.parse(response.text)
 
           holidays.map((holiday) => {
-            expect(holiday.date.slice(0, 4)).toEqual(`${year}`)
+            expect(holiday.observedDate.slice(0, 4)).toEqual(`${year}`)
           })
         })
       })
@@ -280,7 +280,7 @@ describe('Test /api responses', () => {
 
       expect(holiday).toMatchObject({
         id: 17,
-        date: '2020-08-03',
+        observedDate: '2020-08-03',
         nameEn: 'Civic Holiday',
         nameFr: 'Premier lundi d’août',
         federal: 1,
@@ -309,7 +309,7 @@ describe('Test /api responses', () => {
 
           let { holiday } = JSON.parse(response.text)
 
-          expect(holiday.date.slice(0, 4)).toEqual(`${year}`)
+          expect(holiday.observedDate.slice(0, 4)).toEqual(`${year}`)
         })
       })
 

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -44,6 +44,7 @@ describe('Test /api responses', () => {
         nameEn: expect.any(String),
         nameFr: expect.any(String),
         federal: expect.any(Number),
+        date: expect.any(String),
       },
       withProvinces ? provinces : {},
     )
@@ -273,17 +274,18 @@ describe('Test /api responses', () => {
 
   describe('for /api/v1/holidays/:holidayId path', () => {
     test('it should return a holiday for a good ID', async () => {
-      const response = await request(app).get('/api/v1/holidays/17')
+      const response = await request(app).get('/api/v1/holidays/28')
       expect(response.statusCode).toBe(200)
 
       let { holiday } = JSON.parse(response.text)
 
       expect(holiday).toMatchObject({
-        id: 17,
-        observedDate: '2020-08-03',
-        nameEn: 'Civic Holiday',
-        nameFr: 'Premier lundi d’août',
+        id: 28,
+        date: '2020-12-26',
+        nameEn: 'Boxing Day',
+        nameFr: 'Lendemain de Noël',
         federal: 1,
+        observedDate: '2020-12-28',
         provinces: expect.any(Array),
       })
     })

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -20,8 +20,8 @@ const { getHolidaysWithProvinces } = require('../queries')
  */
 const formatNationalEvent = (holiday) => {
   return {
-    start: startDate(holiday.date),
-    end: endDate(holiday.date),
+    start: startDate(holiday.observedDate),
+    end: endDate(holiday.observedDate),
     title: getTitle(holiday),
     description: getNationalDescription(holiday),
     productId: '-//pcraig3//hols//EN',
@@ -35,8 +35,8 @@ const formatNationalEvent = (holiday) => {
  */
 const formatProvinceEvent = (holiday) => {
   return {
-    start: startDate(holiday.date),
-    end: endDate(holiday.date),
+    start: startDate(holiday.observedDate),
+    end: endDate(holiday.observedDate),
     title: holiday.nameEn,
     description: getProvinceDescription(holiday),
     productId: '-//pcraig3//hols//EN',

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -17,7 +17,7 @@ const {
 const { getProvinces, getHolidaysWithProvinces, getProvincesWithHolidays } = require('../queries')
 const { displayDate } = require('../dates')
 
-const getMeta = (holiday) => `${holiday.nameEn} on ${displayDate(holiday.date)}`
+const getMeta = (holiday) => `${holiday.nameEn} on ${displayDate(holiday.observedDate)}`
 
 router.get('/', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, res) => {
   const year = getCurrentHolidayYear()

--- a/src/utils/__tests__/data.skip.js
+++ b/src/utils/__tests__/data.skip.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     id: 1,
-    date: '2019-01-01',
+    observedDate: '2019-01-01',
     nameEn: 'New Year’s Day',
     nameFr: 'Jour de l’An',
     federal: 1,
@@ -23,7 +23,7 @@ module.exports = [
   },
   {
     id: 2,
-    date: '2019-02-18',
+    observedDate: '2019-02-18',
     nameEn: 'Louis Riel Day',
     nameFr: 'Journée Louis Riel',
     federal: 0,
@@ -31,7 +31,7 @@ module.exports = [
   },
   {
     id: 3,
-    date: '2019-02-18',
+    observedDate: '2019-02-18',
     nameEn: 'Islander Day',
     nameFr: 'Fête des Insulaires',
     federal: 0,
@@ -39,7 +39,7 @@ module.exports = [
   },
   {
     id: 4,
-    date: '2019-02-18',
+    observedDate: '2019-02-18',
     nameEn: 'Family Day',
     nameFr: 'Fête de la famille',
     federal: 0,
@@ -53,7 +53,7 @@ module.exports = [
   },
   {
     id: 5,
-    date: '2019-02-18',
+    observedDate: '2019-02-18',
     nameEn: 'Heritage Day',
     nameFr: 'Fête du Patrimoine',
     federal: 0,
@@ -61,7 +61,7 @@ module.exports = [
   },
   {
     id: 6,
-    date: '2019-03-17',
+    observedDate: '2019-03-17',
     nameEn: 'Saint Patrick’s Day',
     nameFr: 'Jour de la Saint-Patrick',
     federal: 0,

--- a/src/utils/__tests__/ics.test.js
+++ b/src/utils/__tests__/ics.test.js
@@ -154,7 +154,7 @@ describe('Test getProvinceDescription', () => {
 describe('Test getUid', () => {
   test('Returns a hash for a holiday object', () => {
     const holiday = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
     }
     const uid = getUid(holiday)
@@ -163,11 +163,11 @@ describe('Test getUid', () => {
 
   test('Different ids for different date, different title', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
     }
     const holiday2 = {
-      date: '2022-10-10',
+      observedDate: '2022-10-10',
       nameEn: 'Thanksgiving',
     }
 
@@ -176,11 +176,11 @@ describe('Test getUid', () => {
 
   test('Different ids for different date, same title', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
     }
     const holiday2 = {
-      date: '2022-02-28',
+      observedDate: '2022-02-28',
       nameEn: 'Family Day',
     }
 
@@ -189,11 +189,11 @@ describe('Test getUid', () => {
 
   test('Different ids for same date, different title', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
     }
     const holiday2 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Louis Riel Day',
     }
 
@@ -202,12 +202,12 @@ describe('Test getUid', () => {
 
   test('Different ids for same date, same title, different provinces', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
       provinces: [{ id: 'ON' }],
     }
     const holiday2 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
       provinces: [{ id: 'BC' }],
     }
@@ -217,12 +217,12 @@ describe('Test getUid', () => {
 
   test('Different ids for same date, same title, one federal', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
       federal: true,
     }
     const holiday2 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
       federal: false,
     }
@@ -232,12 +232,12 @@ describe('Test getUid', () => {
 
   test('Same ids for same date, same title, same provinces', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
       provinces: [{ id: 'ON' }],
     }
     const holiday2 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
       provinces: [{ id: 'ON' }],
     }
@@ -247,11 +247,11 @@ describe('Test getUid', () => {
 
   test('Same ids for same date, same title, no provinces', () => {
     const holiday1 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
     }
     const holiday2 = {
-      date: '2022-02-21',
+      observedDate: '2022-02-21',
       nameEn: 'Family Day',
     }
 

--- a/src/utils/ics.js
+++ b/src/utils/ics.js
@@ -85,7 +85,7 @@ const getProvinceDescription = (holiday) => {
 const getUid = (holiday) => {
   return crypto
     .createHash('sha1')
-    .update(new Date(holiday.date).getTime() + getTitle(holiday))
+    .update(new Date(holiday.observedDate).getTime() + getTitle(holiday))
     .digest('base64')
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -168,10 +168,10 @@ const nextHoliday = (holidays, dateString) => {
   }
 
   const nextDate = holidays.find((holiday) => {
-    return holiday.date >= dateString
-  }).date
+    return holiday.observedDate >= dateString
+  }).observedDate
 
-  const nextHolidays = holidays.filter((holiday) => holiday.date === nextDate)
+  const nextHolidays = holidays.filter((holiday) => holiday.observedDate === nextDate)
 
   nextHolidays.sort((h1, h2) => {
     if (h1.provinces.length <= h2.provinces.length) {
@@ -195,7 +195,7 @@ const upcomingHolidays = (holidays, dateString) => {
     dateString = new Date(Date.now()).toISOString().substring(0, 10)
   }
 
-  return holidays.filter((holiday) => holiday.date >= dateString)
+  return holidays.filter((holiday) => holiday.observedDate >= dateString)
 }
 
 /**


### PR DESCRIPTION
### change 'date' key to 'observedDate' key

the idea here is that the `observedDate` accounts for weekends and tries to find Mondays. the "date" proper is the literal date of the holiday.

So, for example, if Boxing Day is on a Saturday, it is observed the following Monday. The `date` would be the 26th while the `observedDate` would be the 28th.

### Add "date" key to holidays and update Swagger spec

Added back the "date" key as the literal date of the holiday. Makes sense, as this seems like the literal meaning of the word "date".

Updated and version bumped the swagger spec with the changes.

I've decided it's not a breaking change because your code won't be broken, although I have slightly modified the format of the data.
If I had more users, I would consider it a breaking change, but I don't really.

