### PR TITLE
fix layout bug to do with long holidays with too many non-breaking spaces

### DIFF
--- a/src/components/NextHoliday.js
+++ b/src/components/NextHoliday.js
@@ -11,7 +11,9 @@ const NextHoliday = ({ nextHoliday, provinceName = 'Canada', federal }) => {
         >holiday is
       </div>
       <div class="h1--lg"><${DateHtml} dateString=${nextHoliday.observedDate} //></div>
-      <div class="h1--md">${nextHoliday.nameEn.replace(/ /g, '\u00a0')}</div>
+      <div class="h1--md">
+        ${nextHoliday.nameEn.replace(/ /, '\u00a0').replace(/Peoples Day/, 'Peoples\u00a0Day')}
+      </div>
     </h1>
   `
 }

--- a/src/components/__tests__/NextHoliday.test.js
+++ b/src/components/__tests__/NextHoliday.test.js
@@ -18,7 +18,7 @@ const getNextHoliday = ({ federal } = {}) => {
   }
 }
 
-const sp2nbsp = (str) => str.replace(/ /g, '\u00a0')
+const sp2nbsp = (str) => str.replace(/ /, '\u00a0')
 
 describe('NextHoliday', () => {
   test('renders next holiday for Canada page', () => {

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -22,7 +22,7 @@ const getNextHoliday = ({ federal } = {}) => {
   }
 }
 
-const sp2nbsp = (str) => str.replace(/ /g, '\u00a0')
+const sp2nbsp = (str) => str.replace(/ /, '\u00a0')
 
 test('NextHolidayBox displays next holiday properly for Canada', () => {
   const nextHoliday = getNextHoliday()

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -33,7 +33,7 @@ describe('Province page', () => {
   test('renders h1 and h2', () => {
     const $ = renderPage()
     expect($('h1').length).toBe(1)
-    expect($('h1').text()).toEqual('Canada’s next statutory holiday isAugust 16Gold Cup Parade Day')
+    expect($('h1').text()).toEqual('Canada’s next statutory holiday isAugust 16Gold Cup Parade Day')
     expect($('h2').length).toBe(1)
     expect($('h2').text()).toEqual('Canada statutory holidays in 2020')
   })


### PR DESCRIPTION
### only replace the first regular space with a non-breaking space per holiday

the reason for this change is that some of our longer holidays were getting cut off in weird ways because they weren't allowed to break on the spaces.

Most holidays are fairly short, so this should work fine.

## screenshot



| before | after |
|--------|-------|
| <img width="882" alt="Screen Shot 2020-06-04 at 2 16 26 AM" src="https://user-images.githubusercontent.com/2454380/83721687-90a6fa00-a609-11ea-9099-ae222c6b8f97.png">  | <img width="882" alt="Screen Shot 2020-06-04 at 2 16 28 AM" src="https://user-images.githubusercontent.com/2454380/83721682-8e44a000-a609-11ea-8a6e-77af69e548ab.png">     |



