### PR TITLE
Source link layout fix

### DIFF
--- a/migrations/001-db.sql
+++ b/migrations/001-db.sql
@@ -39,11 +39,11 @@ INSERT INTO Province (id, nameEn, nameFr) VALUES ('YT', 'Yukon', 'Yukon');
 
 UPDATE Province SET sourceEn = 'General holidays in Alberta', sourceLink = 'https://www.alberta.ca/alberta-general-holidays.aspx#toc-1' WHERE id = 'AB';
 UPDATE Province SET sourceEn = 'Statutory Holidays in British Columbia', sourceLink = 'https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays#body' WHERE id = 'BC';
-UPDATE Province SET sourceEn = 'General holidays in Manitoba?', sourceLink = 'https://www.gov.mb.ca/labour/standards/doc,gen-holidays-after-april-30-07,factsheet.html#q12' WHERE id = 'MB';
+UPDATE Province SET sourceEn = 'General holidays in Manitoba', sourceLink = 'https://www.gov.mb.ca/labour/standards/doc,gen-holidays-after-april-30-07,factsheet.html#q12' WHERE id = 'MB';
 UPDATE Province SET sourceEn = '10 prescribed days of rest', sourceLink = 'https://www2.gnb.ca/content/gnb/en/departments/elg/local_government/content/governance/content/days_of_rest_act/faq.html#2' WHERE id = 'NB';
 UPDATE Province SET sourceEn = 'Public holidays in Newfoundland', sourceLink = 'https://gist.github.com/pcraig3/81dff348ddf52777c9f918c3032531bd' WHERE id = 'NL';
 UPDATE Province SET sourceEn = 'Paid holidays in Nova Scotia', sourceLink = 'https://novascotia.ca/lae/employmentrights/holidaychart.asp' WHERE id = 'NS';
-UPDATE Province SET sourceEn = 'Employment Standards: Northwest Territories', sourceLink = 'https://www.ece.gov.nt.ca/en/services/employment-standards/frequently-asked-questions' WHERE id = 'NT';
+UPDATE Province SET sourceEn = 'Employment Standards, Northwest Territories', sourceLink = 'https://www.ece.gov.nt.ca/en/services/employment-standards/frequently-asked-questions' WHERE id = 'NT';
 UPDATE Province SET sourceEn = 'Nunavut General Holidays', sourceLink = 'https://nu-lsco.ca/faq-s?tmpl=component&faqid=11' WHERE id = 'NU';
 UPDATE Province SET sourceEn = 'Ontario Public holidays', sourceLink = 'https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays' WHERE id = 'ON';
 UPDATE Province SET sourceEn = 'PEI Paid Holidays', sourceLink = 'https://www.princeedwardisland.ca/en/information/economic-growth-tourism-and-culture/paid-holidays' WHERE id = 'PE';

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -10,15 +10,15 @@ const linkStyles = (color) => css`
     color: ${color ? theme.color[color].accent : theme.color.red};
 
     &.up-arrow::after {
-      content: ' ↑';
+      content: '\u00A0↑';
     }
 
     &.down-arrow::after {
-      content: ' ↓';
+      content: '\u00A0↓';
     }
 
     &.right-arrow::after {
-      content: ' →';
+      content: '\u00A0→';
     }
 
     &:focus {

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -41,6 +41,10 @@ const styles = ({ accent = theme.color.red } = {}) => css`
       margin-top: 0;
     }
 
+    .bottom-link:last-of-type {
+      margin-right: ${theme.space.md};
+    }
+
     .external-link {
       margin-bottom: ${theme.space.xxl};
 
@@ -50,6 +54,7 @@ const styles = ({ accent = theme.color.red } = {}) => css`
       }
 
       svg {
+        padding-left: 2px;
         height: 19.5px;
         width: 19.5px;
         fill: ${accent};
@@ -220,7 +225,7 @@ const Province = ({
               ${source &&
               html`<span class="bottom-link external-link"
                 >Source:${' '}<a href=${source.link} target="_blank"
-                  >${source.nameEn} <${External} /></a
+                  >${source.nameEn}<${External} /></a
               ></span>`}
               <span class="bottom-link"><a href="#html" class="up-arrow">Back to top</a></span>
             </div>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -31,21 +31,22 @@ const styles = ({ accent = theme.color.red } = {}) => css`
   }
 
   .bottom-link__container.with-source {
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    margin-top: -${theme.space.xxl};
 
     @media (${theme.mq.md}) {
-      display: flex;
       flex-direction: row-reverse;
       justify-content: space-between;
+      margin-top: 0;
     }
 
     .external-link {
-      position: absolute;
-      bottom: ${theme.space.xxl};
+      margin-bottom: ${theme.space.xxl};
 
       @media (${theme.mq.md}) {
         position: relative;
-        bottom: unset;
+        margin-bottom: 0;
       }
 
       svg {


### PR DESCRIPTION
Fix a layout glitch we were seeing with long "source" links on small screens.

Using absolute positioning, when the source link ended up on two lines, it would move upwards (and overlap with other content). If we use regular block positioning (flexbox, but you get the picture), the extra space is distributed downwards. 

Introduced some new glitches at certain screen sizes, but I think it's actually NBD.

## screenshot

| before | after |
|--------|-------|
| "Source:" link is touching bottom line of table     | "Source:" link is more comfortable     |
|   <img width="676" alt="Screen Shot 2020-06-04 at 2 30 06 PM" src="https://user-images.githubusercontent.com/2454380/83799998-ae5d7900-a674-11ea-9f53-ce4348956994.png">   | <img width="676" alt="Screen Shot 2020-06-04 at 2 30 03 PM" src="https://user-images.githubusercontent.com/2454380/83800002-b1586980-a674-11ea-9428-48bd47a8495f.png">   |



