### PR TITLE
Add rate limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3441,6 +3441,11 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
+      "integrity": "sha512-TINcxve5510pXj4n9/1AMupkj3iWxl3JuZaWhCdYDlZeoCPqweGZrxbrlqTCFb1CT5wli7s8e2SH/Qz2c9GorA=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "emotion-server": "^10.0.27",
     "express": "^4.17.1",
     "express-openapi-validator": "^3.16.1",
+    "express-rate-limit": "^5.1.3",
     "helmet": "^3.23.0",
     "htm": "^3.0.4",
     "http-errors": "^1.7.3",

--- a/src/config/rateLimit.config.js
+++ b/src/config/rateLimit.config.js
@@ -1,0 +1,19 @@
+const createError = require('http-errors')
+
+// https://github.com/nfriedly/express-rate-limit
+module.exports = {
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 2, // limit each IP to 100 requests per 5 minutes,
+  keyGenerator: function (req) {
+    req.clientIp
+  },
+  handler: function (req, res, options) {
+    const statusCode = 429
+    const count = req.rateLimit.current
+    if (count <= 10 || count % 10 == 0) {
+      res.status(statusCode)
+      throw new createError(options.statusCode, 'Error: Too many requests, please try again later.')
+    }
+    res.status(statusCode).send('Too many requests, please try again later.')
+  },
+}

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -8,6 +8,11 @@ const createError = require('http-errors')
 const renderPage = require('../pages/_document.js')
 const { dbmw } = require('../utils')
 const { getProvincesWithHolidays, getHolidaysWithProvinces } = require('../queries')
+const rateLimit = require('express-rate-limit')
+const rateLimitConfig = require('../config/rateLimit.config')
+
+// Set the rate limiter on the API in prod
+process.env.NODE_ENV === 'production' && v1Router.use(rateLimit(rateLimitConfig))
 
 // Import the express-openapi-validator library
 const OpenApiValidator = require('express-openapi-validator').OpenApiValidator
@@ -79,7 +84,7 @@ apiRouter.get('/', (req, res) => {
   )
 })
 
-apiRouter.use('/v1', v1Router)
+apiRouter.use('/v1', v1Router).use
 
 apiRouter.get('*', (req, res) => {
   res.status(404)

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,15 @@ const helmet = require('helmet')
 const compression = require('compression')
 const csp = require('./config/csp.config')
 const requestIp = require('request-ip')
+const rateLimit = require('express-rate-limit')
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs,
+  keyGenerator: function (req) {
+    req.clientIp
+  },
+})
 
 const app = express()
 
@@ -17,6 +26,7 @@ app
   .use(express.static('public', { maxage: process.env.NODE_ENV === 'production' ? '3d' : '0' }))
   .use(compression())
   .use(requestIp.mw())
+  .use(limiter)
 
 // if NODE_ENV does not equal 'test', add a request logger
 process.env.NODE_ENV !== 'test' && app.use(morgan(morganConfig))

--- a/src/server.js
+++ b/src/server.js
@@ -5,15 +5,6 @@ const helmet = require('helmet')
 const compression = require('compression')
 const csp = require('./config/csp.config')
 const requestIp = require('request-ip')
-const rateLimit = require('express-rate-limit')
-
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs,
-  keyGenerator: function (req) {
-    req.clientIp
-  },
-})
 
 const app = express()
 
@@ -26,7 +17,6 @@ app
   .use(express.static('public', { maxage: process.env.NODE_ENV === 'production' ? '3d' : '0' }))
   .use(compression())
   .use(requestIp.mw())
-  .use(limiter)
 
 // if NODE_ENV does not equal 'test', add a request logger
 process.env.NODE_ENV !== 'test' && app.use(morgan(morganConfig))


### PR DESCRIPTION
### add rate limiter

limit requests to 100 times every 15 minutes using the boilerplate example, with a few modifications.

The other day, I added the 'request-ip' package that tracks ips more robustly than the default express app (at least it seems to).

So we should limit requests based on the 'request-ip' key rather than the default IP.

