### PR TITLE
add google breadcrumbs to rich text results

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,8 @@
 # TODO
 
+- add google rich results 💰
+  - dataset
+  - speakable
 - add next/previous links at the bottom
 - guess location?
 - figure out about optional holidays
@@ -11,6 +14,8 @@
 
 # DONE
 
+- add google rich results 💰
+  - breadcrumbs
 - make it a PWA
 - put days until on main page
   - bug: "days until" counter actually works now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,10 +1,11 @@
 const { renderStylesToString } = require('emotion-server')
 const render = require('preact-render-to-string')
 const { html, metaIfSHA } = require('../utils')
+const { breadcrumb } = require('../utils/richSnippets')
 const { theme } = require('../styles')
 const { fontStyles, printStyles, ga } = require('../headStyles')
 
-const document = ({ title, content, docProps: { meta, path } }) => {
+const document = ({ title, content, docProps: { meta, path, region } }) => {
   return `
     <!DOCTYPE html>
     <html lang="en" id="html">
@@ -106,7 +107,16 @@ const document = ({ title, content, docProps: { meta, path } }) => {
 
           ${printStyles};
         </style>
-        <!-- from https://developers.google.com/web/fundamentals/primers/service-workers/registration -->
+        ${
+          region
+            ? `<!-- rich snippets 💰✂️ -->
+          <script type="application/ld+json">
+            ${JSON.stringify(breadcrumb(region))}
+          </script>`
+            : ''
+        }
+
+        <!-- https://developers.google.com/web/fundamentals/primers/service-workers/registration -->
         <script>
           if ('serviceWorker' in navigator) {
             window.addEventListener('load', function() {

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -32,7 +32,7 @@ router.get('/', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, res) =>
     renderPage({
       pageComponent: 'Province',
       title: `Canadian statutory holidays in ${year}`,
-      docProps: { meta, path: req.path },
+      docProps: { meta, path: req.path, region: 'Canada' },
       props: { data: { holidays, nextHoliday: nextHol, year } },
     }),
   )
@@ -54,7 +54,7 @@ router.get(
       renderPage({
         pageComponent: 'Province',
         title: `Canadian statutory holidays in ${year}`,
-        docProps: { meta, path: req.path },
+        docProps: { meta, path: req.path, region: 'Canada' },
         props: { data: { holidays, nextHoliday: undefined, year } },
       }),
     )
@@ -89,7 +89,7 @@ router.get(
         title: `${provinceName} (${pe2pei(
           provinceId,
         )}) statutory holidays in ${year} — Canada Holidays`,
-        docProps: { meta, path: req.path },
+        docProps: { meta, path: req.path, region: provinceName },
         props: {
           data: {
             holidays,
@@ -130,7 +130,7 @@ router.get(
         title: `${provinceName} (${pe2pei(
           provinceId,
         )}) statutory holidays in ${year} — Canada Holidays`,
-        docProps: { meta, path: req.path },
+        docProps: { meta, path: req.path, region: provinceName },
         props: {
           data: {
             holidays,
@@ -166,7 +166,7 @@ router.get('/federal', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, 
     renderPage({
       pageComponent: 'Province',
       title: `Federal statutory holidays in Canada in ${year}`,
-      docProps: { meta, path: req.path },
+      docProps: { meta, path: req.path, region: 'Federal' },
       props: {
         data: {
           holidays,
@@ -196,7 +196,7 @@ router.get(
       renderPage({
         pageComponent: 'Province',
         title: `Federal statutory holidays in Canada in ${year}`,
-        docProps: { meta, path: req.path },
+        docProps: { meta, path: req.path, region: 'Federal' },
         props: {
           data: { holidays, nextHoliday: undefined, federal: true, year, source: federalSource },
         },

--- a/src/utils/richSnippets.js
+++ b/src/utils/richSnippets.js
@@ -1,0 +1,46 @@
+const breadcrumb = (region) => {
+  const provinceBreadcrumb = {
+    '@type': 'ListItem',
+    position: 2,
+    name: 'Regions',
+    item: 'https://canada-holidays.ca/provinces',
+  }
+
+  let breadcrumbList = [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Canada',
+      item: 'https://canada-holidays.ca/',
+    },
+  ]
+
+  if (region === 'Federal') {
+    breadcrumbList = breadcrumbList.concat([
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: region,
+      },
+    ])
+  } else if (region !== 'Canada') {
+    breadcrumbList = breadcrumbList.concat([
+      provinceBreadcrumb,
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: region,
+      },
+    ])
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbList,
+  }
+}
+
+module.exports = {
+  breadcrumb,
+}


### PR DESCRIPTION
Only on 3 types of pages:

- Canada (+years)
  - `Canada`
- Federal (+ years)
  - `Canada > Federal`
- Provinces (+ Years)
  - `Canada > Regions > Alberta`

Can't really do a screenshot because there are no screens to shoot 🔫 🚫 