### PR TITLE
Add speakable rich results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2020-10-21
+
+### Added
+
+- Breadcrumbs rich search results. Does it matter? Maybe.
+
 ## [2.9.0] - 2020-10-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2020-10-21
+
+### Added
+
+- Speakable rich search results. Still in beta but could be fun.
+- SR-only text for the h1 on "next holiday" pages. Makes it flow better
+
+### Updated
+
+- Added aria-labels for province names in the "observed by" paragraph. sounds nicer.
+
+### Fixed
+
+- Removed "visuallyHidden" css emotion class in favour of a regular classname. Means it works as expected in FF, at least.
+
 ## [2.10.0] - 2020-10-21
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - add google rich results 💰
   - dataset
-  - speakable
 - add next/previous links at the bottom
 - guess location?
 - figure out about optional holidays
@@ -14,8 +13,10 @@
 
 # DONE
 
+- make screen reader improvements for the "next holidays" page
 - add google rich results 💰
   - breadcrumbs
+  - speakable
 - make it a PWA
 - put days until on main page
   - bug: "days until" counter actually works now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,61 +8,61 @@
 
 <url>
   <loc>https://canada-holidays.ca/</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
@@ -80,151 +80,151 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/AB/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/BC/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NB/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/ON/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/SK/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
@@ -236,241 +236,241 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/MB/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/PE/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NS/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NL/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/QC/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NT/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/NU/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT</loc>
-  <lastmod>2020-07-02T01:45:23+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2018</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2019</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2021</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/province/YT/2022</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-10-22T05:36:33+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>

--- a/src/components/NextHoliday.js
+++ b/src/components/NextHoliday.js
@@ -1,27 +1,35 @@
 const { html } = require('../utils')
 const DateHtml = require('./DateHtml.js')
-const { visuallyHidden } = require('../styles')
+const { displayDate } = require('../dates')
+
+const screenReaderTitle = (nextHoliday, provinceName, federal) => {
+  return `${provinceName}’${provinceName.slice(-1) === 's' ? '' : 's'} next ${
+    federal ? 'federal ' : ''
+  }statutory holiday is ${nextHoliday.nameEn}, on ${displayDate(nextHoliday.observedDate)}.`
+}
 
 const NextHoliday = ({ nextHoliday, provinceName = 'Canada', federal }) => {
   return html`
     <h1>
-      <div class="h1--xs">
-        ${provinceName}’${provinceName.slice(-1) === 's' ? '' : 's'}
-        ${' '}next${' '}${federal && 'federal '}<span class=${visuallyHidden}>statutory </span
-        >holiday${' '.replace(/ /, '\u00a0')}is
-      </div>
-      <div class="h1--lg">
-        <a href="#next-holiday-row"
-          ><${DateHtml} data-event="true" data-action="next-holidays-row-link"
-          data-label=${`next-holidays-row-link-${
-            federal ? 'federal' : provinceName.replace(/\s+/g, '-').toLowerCase()
-          }`}
-          dateString=${nextHoliday.observedDate} //></a
-        >
-      </div>
-      <div class="h1--md">
-        ${nextHoliday.nameEn.replace(/ /, '\u00a0').replace(/Peoples Day/, 'Peoples\u00a0Day')}
-      </div>
+      <span class="visuallyHidden">${screenReaderTitle(nextHoliday, provinceName, federal)}</span>
+      <span aria-hidden="true">
+        <div class="h1--xs">
+          ${provinceName}’${provinceName.slice(-1) === 's' ? '' : 's'}
+          ${' '}next${' '}${federal && 'federal '}holiday${' '.replace(/ /, '\u00a0')}is
+        </div>
+        <div class="h1--lg">
+          <a href="#next-holiday-row"
+            ><${DateHtml} data-event="true" data-action="next-holidays-row-link"
+            data-label=${`next-holidays-row-link-${
+              federal ? 'federal' : provinceName.replace(/\s+/g, '-').toLowerCase()
+            }`}
+            dateString=${nextHoliday.observedDate} //></a
+          >
+        </div>
+        <div class="h1--md">
+          ${nextHoliday.nameEn.replace(/ /, '\u00a0').replace(/Peoples Day/, 'Peoples\u00a0Day')}
+        </div>
+      </span>
     </h1>
   `
 }

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -91,7 +91,7 @@ const styles = ({
 
 const renderNextHolidayTitle = ({ nextHoliday, provinceName, federal }) => {
   return html`<${NextHoliday} ...${{ nextHoliday, provinceName, federal }} //>
-    <p>${relativeDate(nextHoliday.observedDate)}</p>
+    <p>${relativeDate(nextHoliday.observedDate)}<span class="visuallyHidden">.</span></p>
     ${provinceName == 'Canada' &&
     !federal &&
     html`<${ObservingProvinces} provinces=${nextHoliday.provinces} federal=${nextHoliday.federal}

--- a/src/components/NextHolidayBox.js
+++ b/src/components/NextHolidayBox.js
@@ -1,6 +1,6 @@
 const { css } = require('emotion')
 const { html, getProvinceIdOrFederalString } = require('../utils')
-const { theme, insideContainer, horizontalPadding, visuallyHidden } = require('../styles')
+const { theme, insideContainer, horizontalPadding } = require('../styles')
 const NextHoliday = require('./NextHoliday.js')
 const ObservingProvinces = require('./ObservingProvinces.js')
 const ProvinceTitle = require('./ProvinceTitle.js')
@@ -129,10 +129,7 @@ const NextHolidayBox = ({ nextHoliday, provinceName = 'Canada', provinceId, fede
         federal &&
         html`
           <p>
-            <a href="/do-federal-holidays-apply-to-me"
-              >Find out who gets federal${' '}
-              <span class=${visuallyHidden}>statutory </span>holidays</a
-            >
+            <a href="/do-federal-holidays-apply-to-me">Find out who gets federal holidays</a>
           </p>
         `}
       </div>

--- a/src/components/ObservingProvinces.js
+++ b/src/components/ObservingProvinces.js
@@ -6,7 +6,12 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
   }
 
   if (provinces.length === 0) {
-    return federal ? html`<p>Observed by${' '}<a href="/federal">federal industries</a></p>` : ''
+    return federal
+      ? html`<p>
+          Observed by${' '}<a href="/federal">federal industries</a
+          ><span class="visuallyHidden">.</span>
+        </p>`
+      : ''
   }
 
   if (provinces.length === 1) {
@@ -15,11 +20,13 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
           <p>
             Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
             ${' '}and by${' '}<a href="/federal">federal industries</a>
+            <span class="visuallyHidden">.</span>
           </p>
         `
       : html`
           <p>
             Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+            <span class="visuallyHidden">.</span>
           </p>
         `
   }
@@ -31,12 +38,14 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
             Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>,
             ${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn},</a>${' '}and
             ${' '}by${' '}<a href="/federal">federal industries</a>
+            <span class="visuallyHidden">.</span>
           </p>
         `
       : html`
           <p>
             Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
             ${' '}and${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn}</a>
+            <span class="visuallyHidden">.</span>
           </p>
         `
   }
@@ -48,9 +57,12 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
       <p>
         Observed in
         ${provinces.map(
-          (p) => html`${' '}<a href=${`/province/${p.id}`}>${pe2pei(p.id)}</a>${','}`,
+          (p) =>
+            html`${' '}<a href=${`/province/${p.id}`} aria-label=${p.nameEn}>${pe2pei(p.id)}</a
+              >${','}`,
         )}
         ${' '}and by${' '}<a href="/federal">federal industries</a>
+        <span class="visuallyHidden">.</span>
       </p>
     `
   }
@@ -60,10 +72,12 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
       Observed in
       ${provinces.map(
         (p) => html`
-          ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`}>${pe2pei(p.id)}</a
+          ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`} aria-label=${p.nameEn}
+            >${pe2pei(p.id)}</a
           >${isLastProvince(p) ? '' : ','}
         `,
       )}
+      <span class="visuallyHidden">.</span>
     </p>
   `
 }

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -1,13 +1,7 @@
 const { html, getProvinceIdOrFederalString } = require('../utils')
 const { css } = require('emotion')
 const { ALLOWED_YEARS, PROVINCE_IDS } = require('../config/vars.config')
-const {
-  theme,
-  insideContainer,
-  hiddenOnMobile,
-  horizontalPadding,
-  visuallyHidden,
-} = require('../styles')
+const { theme, insideContainer, hiddenOnMobile, horizontalPadding } = require('../styles')
 const Button = require('./Button')
 
 const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) => css`
@@ -36,7 +30,7 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
       margin-right: ${theme.space.xs};
     }
 
-    &:last-of-type{
+    &:last-of-type {
       display: block;
 
       @media (${theme.mq.md}) {
@@ -78,9 +72,9 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
     color: ${theme.color.grey};
     background-color: transparent;
     background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23${accent.replace(
-      /#/g,
-      '',
-    )}%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+        /#/g,
+        '',
+      )}%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
       linear-gradient(to bottom, white 0%, white 100%);
     background-repeat: no-repeat, repeat;
     background-position: right ${theme.space.xs} top 50%, 0 0;
@@ -119,11 +113,11 @@ const styles = ({ accent = theme.color.red, focus = theme.color.focus } = {}) =>
   }
 
   .js & {
-    *[data-display-none="true"] {
+    *[data-display-none='true'] {
       display: none;
     }
 
-    *[data-hidden="true"] {
+    *[data-hidden='true'] {
       visibility: hidden;
     }
   }
@@ -174,7 +168,7 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
           <div>
             <div id="region-select-width" aria-hidden="true">${regionName}</div>
 
-            <label for="region-select" class=${visuallyHidden}>View by region</label>
+            <label for="region-select" class="visuallyHidden">View by region</label>
             <span class=${hiddenOnMobile} aria-hidden="true">See</span>
             <select
               name="region"
@@ -188,15 +182,15 @@ const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
               <option disabled>──────────</option>
               ${PROVINCE_IDS.map(
                 (pid) =>
-                  html`<option value=${pid} selected=${provinceId === pid}
-                    >${getProvinceNameFromId(pid)}</option
-                  >`,
+                  html`<option value=${pid} selected=${provinceId === pid}>
+                    ${getProvinceNameFromId(pid)}
+                  </option>`,
               )}
             </select>
           </div>
 
           <div>
-            <label for="year-select" class=${visuallyHidden}>View by year</label>
+            <label for="year-select" class="visuallyHidden">View by year</label>
             <span aria-hidden="true">holidays for</span>
             <select
               name="year"

--- a/src/components/ProvinceTitle.js
+++ b/src/components/ProvinceTitle.js
@@ -1,12 +1,11 @@
 const { html } = require('../utils')
-const { visuallyHidden } = require('../styles')
 
 const ProvinceTitle = ({ provinceName = 'Canada', federal, year }) => {
   return html`
     <h1>
       <div class="h1--lg">${provinceName}</div>
       <div class="h1--md">
-        ${federal ? 'Federal ' : ''}<span class=${visuallyHidden}>statutory</span>${federal
+        ${federal ? 'Federal ' : ''}<span class="visuallyHidden">statutory</span>${federal
           ? ' h'
           : ' H'}olidays${` in ${year}`}
       </div>

--- a/src/components/__tests__/NextHoliday.test.js
+++ b/src/components/__tests__/NextHoliday.test.js
@@ -26,7 +26,7 @@ describe('NextHoliday', () => {
     const $ = renderNextHoliday({ nextHoliday })
 
     expect($('h1').length).toBe(1)
-    expect($('.h1--xs').text()).toEqual('Canada’s next statutory holiday\u00a0is')
+    expect($('.h1--xs').text()).toEqual('Canada’s next holiday\u00a0is')
     expect($('.h1--lg').text()).toEqual(`${sp2nbsp('August 16')}`)
     expect($('.h1--md').text()).toEqual(`${sp2nbsp(nextHoliday.nameEn)}`)
   })
@@ -36,7 +36,7 @@ describe('NextHoliday', () => {
     const $ = renderNextHoliday({ nextHoliday, provinceName: 'Prince Edward Island' })
 
     expect($('h1').length).toBe(1)
-    expect($('.h1--xs').text()).toEqual('Prince Edward Island’s next statutory holiday\u00a0is')
+    expect($('.h1--xs').text()).toEqual('Prince Edward Island’s next holiday\u00a0is')
   })
 
   test('renders a province-specific intro without the trailing "s" for NT province page', () => {
@@ -44,7 +44,7 @@ describe('NextHoliday', () => {
     const $ = renderNextHoliday({ nextHoliday, provinceName: 'Northwest Territories' })
 
     expect($('h1').length).toBe(1)
-    expect($('.h1--xs').text()).toEqual('Northwest Territories’ next statutory holiday\u00a0is')
+    expect($('.h1--xs').text()).toEqual('Northwest Territories’ next holiday\u00a0is')
   })
 
   // renders for a federal page
@@ -53,6 +53,6 @@ describe('NextHoliday', () => {
     const $ = renderNextHoliday({ nextHoliday, federal: true })
 
     expect($('h1').length).toBe(1)
-    expect($('.h1--xs').text()).toEqual('Canada’s next federal statutory holiday\u00a0is')
+    expect($('.h1--xs').text()).toEqual('Canada’s next federal holiday\u00a0is')
   })
 })

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -49,7 +49,7 @@ test('NextHolidayBox refers to federal holidays when "federal" variable is passe
     `Canada’s next federal holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
   expect($('h1 + p').text()).toMatch(/That’s in (about )?\d+ (days|month(s)?|year)/)
-  expect($('h1 + p + p').text()).toEqual('Find out who gets federal statutory holidays')
+  expect($('h1 + p + p').text()).toEqual('Find out who gets federal holidays')
 })
 
 test('NextHolidayBox displays next holiday properly for a given province', () => {

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -29,8 +29,11 @@ test('NextHolidayBox displays next holiday properly for Canada', () => {
   const $ = renderNextHolidayBox({ nextHoliday })
 
   expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Canada’s next statutory holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
+  expect($('h1 span.visuallyHidden').text()).toEqual(
+    `Canada’s next statutory holiday is ${nextHoliday.nameEn}, on ${sp2nbsp('August 16')}.`,
+  )
+  expect($('h1 span:last-of-type').text()).toEqual(
+    `Canada’s next holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
 })
 
@@ -39,10 +42,11 @@ test('NextHolidayBox refers to federal holidays when "federal" variable is passe
   const $ = renderNextHolidayBox({ nextHoliday, federal: true })
 
   expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Canada’s next federal statutory holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(
-      nextHoliday.nameEn,
-    )}`,
+  expect($('h1 span.visuallyHidden').text()).toEqual(
+    `Canada’s next federal statutory holiday is ${nextHoliday.nameEn}, on ${sp2nbsp('August 16')}.`,
+  )
+  expect($('h1 span:last-of-type').text()).toEqual(
+    `Canada’s next federal holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(nextHoliday.nameEn)}`,
   )
   expect($('h1 + p').text()).toMatch(/That’s in (about )?\d+ (days|month(s)?|year)/)
   expect($('h1 + p + p').text()).toEqual('Find out who gets federal statutory holidays')
@@ -58,26 +62,13 @@ test('NextHolidayBox displays next holiday properly for a given province', () =>
   })
 
   expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Prince Edward Island’s next statutory holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(
-      nextHoliday.nameEn,
+  expect($('h1 span.visuallyHidden').text()).toEqual(
+    `Prince Edward Island’s next statutory holiday is ${nextHoliday.nameEn}, on ${sp2nbsp(
+      'August 16.',
     )}`,
   )
-  expect($('h1 + p').text()).toMatch(/That’s in (about )?\d+ (days|month(s)?|year)/)
-})
-
-test('NextHolidayBox displays next holiday properly for a given province', () => {
-  const nextHoliday = getNextHoliday()
-  delete nextHoliday.provinces
-
-  const $ = renderNextHolidayBox({
-    nextHoliday,
-    provinceName: getProvince().nameEn,
-  })
-
-  expect($('div h1').length).toBe(1)
-  expect($('h1').text()).toEqual(
-    `Prince Edward Island’s next statutory holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(
+  expect($('h1 span:last-of-type').text()).toEqual(
+    `Prince Edward Island’s next holiday\u00a0is${sp2nbsp('August 16')}${sp2nbsp(
       nextHoliday.nameEn,
     )}`,
   )

--- a/src/components/__tests__/ObservingProvinces.test.js
+++ b/src/components/__tests__/ObservingProvinces.test.js
@@ -34,21 +34,21 @@ describe('ObservingProvinces', () => {
     const provinces = getProvinces(1)
 
     const $ = renderObservingProvinces({ provinces })
-    expect($('p').text()).toEqual('Observed in Prince Edward Island')
+    expect($('p').text()).toEqual('Observed in Prince Edward Island.')
   })
 
   test('refers to provinces by full name when less than 3 provinces exist', () => {
     const provinces = getProvinces(2)
 
     const $ = renderObservingProvinces({ provinces })
-    expect($('p').text()).toEqual('Observed in Prince Edward Island and Quebec')
+    expect($('p').text()).toEqual('Observed in Prince Edward Island and Quebec.')
   })
 
   test('refers to provinces by ID when at least 3 provinces exist', () => {
     const provinces = getProvinces(3)
 
     const $ = renderObservingProvinces({ provinces })
-    expect($('p').text()).toEqual('Observed in PEI, QC, and SK')
+    expect($('p').text()).toEqual('Observed in PEI, QC, and SK.')
   })
 
   describe('with federal industries', () => {
@@ -56,14 +56,14 @@ describe('ObservingProvinces', () => {
       const provinces = []
 
       const $ = renderObservingProvinces({ provinces, federal: true })
-      expect($('p').text()).toEqual('Observed by federal industries')
+      expect($('p').text()).toEqual('Observed by federal industries.')
     })
 
     test('refers to one province by full name and federal industries when only one province exists', () => {
       const provinces = getProvinces(1)
 
       const $ = renderObservingProvinces({ provinces, federal: true })
-      expect($('p').text()).toEqual('Observed in Prince Edward Island and by federal industries')
+      expect($('p').text()).toEqual('Observed in Prince Edward Island and by federal industries.')
     })
 
     test('refers to provinces by full name and federal industries when less than 3 provinces exist', () => {
@@ -71,7 +71,7 @@ describe('ObservingProvinces', () => {
 
       const $ = renderObservingProvinces({ provinces, federal: true })
       expect($('p').text()).toEqual(
-        'Observed in Prince Edward Island, Quebec, and by federal industries',
+        'Observed in Prince Edward Island, Quebec, and by federal industries.',
       )
     })
 
@@ -79,7 +79,7 @@ describe('ObservingProvinces', () => {
       const provinces = getProvinces(3)
 
       const $ = renderObservingProvinces({ provinces, federal: true })
-      expect($('p').text()).toEqual('Observed in PEI, QC, SK, and by federal industries')
+      expect($('p').text()).toEqual('Observed in PEI, QC, SK, and by federal industries.')
     })
   })
 

--- a/src/pages/AddHolidays.js
+++ b/src/pages/AddHolidays.js
@@ -1,6 +1,6 @@
 const { html } = require('../utils')
 const { css } = require('emotion')
-const { theme, visuallyHidden } = require('../styles')
+const { theme } = require('../styles')
 const Layout = require('../components/Layout.js')
 const Content = require('../components/Content.js')
 const Button = require('../components/Button.js')
@@ -63,7 +63,7 @@ const AddHolidays = ({ data: { provinces, year } }) => {
             { key: 'Canada', value: downloadButton({ year }), className: summaryTableStyles },
           ]}
         >
-          <h2>Download all Canadian <span class=${visuallyHidden}>statutory</span> holidays</h2>
+          <h2>Download all Canadian <span class="visuallyHidden">statutory</span> holidays</h2>
           <p>For the Canadian completist.</p>
         <//>
 
@@ -78,7 +78,7 @@ const AddHolidays = ({ data: { provinces, year } }) => {
           ]}
         >
           <h2>
-            Download federally-regulated <span class=${visuallyHidden}>statutory</span> holidays
+            Download federally-regulated <span class="visuallyHidden">statutory</span> holidays
           </h2>
           <p>
             For airline pilots, federal policy wonks, etc.${' '}
@@ -88,12 +88,12 @@ const AddHolidays = ({ data: { provinces, year } }) => {
         <//>
 
         <${SummaryTable} title="Regional holidays" rows=${createRows({ provinces, year })}>
-          <h2>Download regional <span class=${visuallyHidden}>statutory</span> holidays</h2>
+          <h2>Download regional <span class="visuallyHidden">statutory</span> holidays</h2>
           <p>For regular folks or secessionists.</p>
         <//>
 
         <h2 id="import-holidays">
-          Import <span class=${visuallyHidden}>statutory</span> holidays into your calendar
+          Import <span class="visuallyHidden">statutory</span> holidays into your calendar
         </h2>
         <p>
           Download Canadian holidays and then import them to your Outlook, iCal, or Google Calendar.

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -1,6 +1,6 @@
 const { css } = require('emotion')
 const { html, pe2pei, getProvinceIdOrFederalString } = require('../utils')
-const { theme, visuallyHidden, horizontalPadding, insideContainer } = require('../styles')
+const { theme, horizontalPadding, insideContainer } = require('../styles')
 const Layout = require('../components/Layout.js')
 const DateHtml = require('../components/DateHtml.js')
 const NextHolidayBox = require('../components/NextHolidayBox.js')
@@ -193,7 +193,7 @@ const Province = ({
               html` <div class=${titleStyles}>
                 <h2 id="holidays-table">
                   ${provinceName}${federal ? ' federal' : ''}
-                  <span class=${visuallyHidden}> statutory</span> holidays in ${year}
+                  <span class="visuallyHidden"> statutory</span> holidays in ${year}
                 </h2>
                 <div>
                   <${CalButton} provinceId=${provinceId} federal=${federal} year=${year}

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -33,7 +33,9 @@ describe('Province page', () => {
   test('renders h1 and h2', () => {
     const $ = renderPage()
     expect($('h1').length).toBe(1)
-    expect($('h1').text()).toEqual('Canada’s next statutory holiday\u00a0isDecember 28Boxing Day')
+    expect($('h1 span:last-of-type').text()).toEqual(
+      'Canada’s next holiday\u00a0isDecember 28Boxing Day',
+    )
     expect($('h2').length).toBe(1)
     expect($('h2').text()).toEqual('Canada statutory holidays in 2020')
     // check the data label is lowercasing the province name

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -2,7 +2,7 @@ const { renderStylesToString } = require('emotion-server')
 const render = require('preact-render-to-string')
 const { html, metaIfSHA } = require('../utils')
 const { breadcrumb } = require('../utils/richSnippets')
-const { theme } = require('../styles')
+const { theme, visuallyHidden } = require('../styles')
 const { fontStyles, printStyles, ga } = require('../headStyles')
 
 const document = ({ title, content, docProps: { meta, path, region } }) => {
@@ -103,6 +103,10 @@ const document = ({ title, content, docProps: { meta, path, region } }) => {
 
           .pcraig3 {
             color: ${theme.color.red};
+          }
+
+          .visuallyHidden {
+            ${visuallyHidden}
           }
 
           ${printStyles};

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,11 +1,11 @@
 const { renderStylesToString } = require('emotion-server')
 const render = require('preact-render-to-string')
 const { html, metaIfSHA } = require('../utils')
-const { breadcrumb } = require('../utils/richSnippets')
+const { breadcrumb, speakable } = require('../utils/richSnippets')
 const { theme, visuallyHidden } = require('../styles')
 const { fontStyles, printStyles, ga } = require('../headStyles')
 
-const document = ({ title, content, docProps: { meta, path, region } }) => {
+const document = ({ title, content, docProps: { meta, path, region, richSnippets } }) => {
   return `
     <!DOCTYPE html>
     <html lang="en" id="html">
@@ -112,11 +112,17 @@ const document = ({ title, content, docProps: { meta, path, region } }) => {
           ${printStyles};
         </style>
         ${
-          region
+          richSnippets
             ? `<!-- rich snippets 💰✂️ -->
-          <script type="application/ld+json">
-            ${JSON.stringify(breadcrumb(region))}
-          </script>`
+              <script type="application/ld+json">
+                ${
+                  richSnippets.length === 1
+                    ? JSON.stringify(breadcrumb(region))
+                    : `[
+                        ${JSON.stringify(breadcrumb(region))},
+                        ${JSON.stringify(speakable(region, path))}]`
+                }
+              </script>`
             : ''
         }
 

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -33,7 +33,7 @@ describe('Test ui responses', () => {
     test('it should return the h1, title, and meta tag', async () => {
       const response = await request(app).get('/')
       const $ = cheerio.load(response.text)
-      expect($('h1').text()).toMatch(/^Canada’s next statutory holiday\u00a0is/)
+      expect($('h1 span:last-of-type').text()).toMatch(/^Canada’s next holiday\u00a0is/)
       expect($('title').text()).toEqual('Canadian statutory holidays in 2020')
       expect($('meta[name="description"]').attr('content')).toMatch(
         /^Canada’s next stat holiday is/,
@@ -178,7 +178,7 @@ describe('Test ui responses', () => {
       test('it should return the h1, title, and meta tag', async () => {
         const response = await request(app).get('/province/MB')
         const $ = cheerio.load(response.text)
-        expect($('h1').text()).toMatch(/^Manitoba’s next statutory holiday\u00a0is/)
+        expect($('h1 span:last-of-type').text()).toMatch(/^Manitoba’s next holiday\u00a0is/)
         expect($('title').text()).toEqual(
           'Manitoba (MB) statutory holidays in 2020 — Canada Holidays',
         )
@@ -222,7 +222,7 @@ describe('Test ui responses', () => {
       test('it should return the h1, title, and meta tag', async () => {
         const response = await request(app).get('/federal')
         const $ = cheerio.load(response.text)
-        expect($('h1').text()).toMatch(/^Canada’s next federal statutory holiday\u00a0is/)
+        expect($('h1 span:last-of-type').text()).toMatch(/^Canada’s next federal holiday\u00a0is/)
         expect($('title').text()).toEqual('Federal statutory holidays in Canada in 2020')
         expect($('meta[name="description"]').attr('content')).toMatch(
           /^Canada’s next federal stat holiday is/,

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -32,7 +32,12 @@ router.get('/', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, res) =>
     renderPage({
       pageComponent: 'Province',
       title: `Canadian statutory holidays in ${year}`,
-      docProps: { meta, path: req.path, region: 'Canada' },
+      docProps: {
+        meta,
+        path: req.path,
+        region: 'Canada',
+        richSnippets: ['breadcrumb', 'speakable'],
+      },
       props: { data: { holidays, nextHoliday: nextHol, year } },
     }),
   )
@@ -54,7 +59,12 @@ router.get(
       renderPage({
         pageComponent: 'Province',
         title: `Canadian statutory holidays in ${year}`,
-        docProps: { meta, path: req.path, region: 'Canada' },
+        docProps: {
+          meta,
+          path: req.path,
+          region: 'Canada',
+          richSnippets: ['breadcrumb'],
+        },
         props: { data: { holidays, nextHoliday: undefined, year } },
       }),
     )
@@ -89,7 +99,12 @@ router.get(
         title: `${provinceName} (${pe2pei(
           provinceId,
         )}) statutory holidays in ${year} — Canada Holidays`,
-        docProps: { meta, path: req.path, region: provinceName },
+        docProps: {
+          meta,
+          path: req.path,
+          region: provinceName,
+          richSnippets: ['breadcrumb', 'speakable'],
+        },
         props: {
           data: {
             holidays,
@@ -130,7 +145,12 @@ router.get(
         title: `${provinceName} (${pe2pei(
           provinceId,
         )}) statutory holidays in ${year} — Canada Holidays`,
-        docProps: { meta, path: req.path, region: provinceName },
+        docProps: {
+          meta,
+          path: req.path,
+          region: provinceName,
+          richSnippets: ['breadcrumb'],
+        },
         props: {
           data: {
             holidays,
@@ -166,7 +186,12 @@ router.get('/federal', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, 
     renderPage({
       pageComponent: 'Province',
       title: `Federal statutory holidays in Canada in ${year}`,
-      docProps: { meta, path: req.path, region: 'Federal' },
+      docProps: {
+        meta,
+        path: req.path,
+        region: 'Federal',
+        richSnippets: ['breadcrumb', 'speakable'],
+      },
       props: {
         data: {
           holidays,
@@ -196,7 +221,12 @@ router.get(
       renderPage({
         pageComponent: 'Province',
         title: `Federal statutory holidays in Canada in ${year}`,
-        docProps: { meta, path: req.path, region: 'Federal' },
+        docProps: {
+          meta,
+          path: req.path,
+          region: 'Federal',
+          richSnippets: ['breadcrumb'],
+        },
         props: {
           data: { holidays, nextHoliday: undefined, federal: true, year, source: federalSource },
         },

--- a/src/styles.js
+++ b/src/styles.js
@@ -51,7 +51,7 @@ const pageMargin = css`
   padding: 0 ${theme.space.md};
 `
 
-const visuallyHidden = css`
+const visuallyHidden = `
   position: absolute !important;
   width: 1px !important;
   height: 1px !important;

--- a/src/utils/richSnippets.js
+++ b/src/utils/richSnippets.js
@@ -41,6 +41,25 @@ const breadcrumb = (region) => {
   }
 }
 
+const speakable = (region, path) => {
+  const name =
+    region === 'Federal'
+      ? 'Canada’s next federal holiday'
+      : `${region}’${region.slice(-1) === 's' ? '' : 's'} next holiday`
+
+  return {
+    '@context': 'https://schema.org/',
+    '@type': 'WebPage',
+    name,
+    speakable: {
+      '@type': 'SpeakableSpecification',
+      cssSelector: region === 'Canada' ? ['h1', 'h1 ~ p'] : ['h1', 'h1 + p'],
+    },
+    url: `https://canada-holidays.ca${path}`,
+  }
+}
+
 module.exports = {
   breadcrumb,
+  speakable,
 }


### PR DESCRIPTION
This PR does a few things, mostly in the service of the speakable rich results.

- Adds rich results metadata for "speakable" type
- makes the H1 read better for screen readers
- makes the "observed provinces" sentence read better for screen readers
- removes the "visuallyHidden" css object in favour of a good ol' class
- updates sitemap for changed urls

Still in beta but maybe it will work. If not, at least the screen reader improvments are good.

Sources: 
- https://developers.google.com/search/docs/data-types/speakable