### PR TITLE
Added dataset rich results + add holiday count to meta description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2020-10-26
+
+### Added
+
+- Rich results for datasets. Added metadata to pages for all provincial, federal, and national holidays.
+
+### Updated
+
+- Added holidays count to the meta string for each region.
+
+
 ## [2.11.1] - 2020-10-21
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
-- add google rich results 💰
-  - dataset
+- Change province urls to provinces to match API (so dumb)
 - add next/previous links at the bottom
 - guess location?
 - figure out about optional holidays
@@ -17,6 +16,7 @@
 - add google rich results 💰
   - breadcrumbs
   - speakable
+  - dataset
 - make it a PWA
 - put days until on main page
   - bug: "days until" counter actually works now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,11 +1,11 @@
 const { renderStylesToString } = require('emotion-server')
 const render = require('preact-render-to-string')
 const { html, metaIfSHA } = require('../utils')
-const { breadcrumb, speakable } = require('../utils/richSnippets')
+const { breadcrumb, dataset, speakable } = require('../utils/richSnippets')
 const { theme, visuallyHidden } = require('../styles')
 const { fontStyles, printStyles, ga } = require('../headStyles')
 
-const document = ({ title, content, docProps: { meta, path, region, richSnippets } }) => {
+const document = ({ title, content, docProps: { meta, path, region, richSnippets, year } }) => {
   return `
     <!DOCTYPE html>
     <html lang="en" id="html">
@@ -112,13 +112,15 @@ const document = ({ title, content, docProps: { meta, path, region, richSnippets
           richSnippets
             ? `<!-- rich snippets 💰✂️ -->
               <script type="application/ld+json">
-                ${
-                  richSnippets.length === 1
-                    ? JSON.stringify(breadcrumb(region))
-                    : `[
-                        ${JSON.stringify(breadcrumb(region))},
-                        ${JSON.stringify(speakable(region, path))}]`
-                }
+                [
+                  ${JSON.stringify(breadcrumb({ region }))},
+                  ${JSON.stringify(dataset({ region, path, year, title, meta }))}
+                  ${
+                    richSnippets.length === 3
+                      ? `, ${JSON.stringify(speakable({ region, path }))}`
+                      : ''
+                  }
+                ]
               </script>`
             : ''
         }

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -39,7 +39,7 @@ describe('Test ui responses', () => {
         /^Canada’s next stat holiday is/,
       )
       expect($('meta[name="description"]').attr('content')).toMatch(
-        /See all statutory holidays in Canada in 2020./,
+        /See all \d{1,2} statutory holidays in Canada in 2020./,
       )
     })
 
@@ -55,8 +55,8 @@ describe('Test ui responses', () => {
       const $ = cheerio.load(response.text)
       expect($('h1').text()).toEqual('Canadastatutory Holidays in 2021')
       expect($('title').text()).toEqual('Canadian statutory holidays in 2021')
-      expect($('meta[name="description"]').attr('content')).toEqual(
-        'See all statutory holidays in Canada in 2021.',
+      expect($('meta[name="description"]').attr('content')).toMatch(
+        /See all \d{1,2} statutory holidays in Canada in 2021./,
       )
     })
   })
@@ -186,7 +186,7 @@ describe('Test ui responses', () => {
           /^Manitoba’s next stat holiday is/,
         )
         expect($('meta[name="description"]').attr('content')).toMatch(
-          /See all statutory holidays in Manitoba, Canada in 2020/,
+          /See all \d{1,2} statutory holidays in Manitoba, Canada in 2020/,
         )
       })
     })
@@ -207,8 +207,8 @@ describe('Test ui responses', () => {
         expect($('title').text()).toEqual(
           'Manitoba (MB) statutory holidays in 2021 — Canada Holidays',
         )
-        expect($('meta[name="description"]').attr('content')).toEqual(
-          'See all statutory holidays in Manitoba, Canada in 2021.',
+        expect($('meta[name="description"]').attr('content')).toMatch(
+          /See all \d{1,2} statutory holidays in Manitoba, Canada in 2021./,
         )
       })
     })
@@ -236,8 +236,8 @@ describe('Test ui responses', () => {
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('CanadaFederal statutory holidays in 2021')
         expect($('title').text()).toEqual('Federal statutory holidays in Canada in 2021')
-        expect($('meta[name="description"]').attr('content')).toEqual(
-          'See all federal statutory holidays in Canada in 2021.',
+        expect($('meta[name="description"]').attr('content')).toMatch(
+          /See all \d{1,2} federal statutory holidays in Canada in 2021./,
         )
       })
     })

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -24,9 +24,9 @@ router.get('/', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, res) =>
   const holidays = res.locals.rows
   const nextHol = nextHoliday(holidays)
 
-  const meta = `Canada’s next stat holiday is ${getMeta(
-    nextHol,
-  )}. See all statutory holidays in Canada in ${year}.`
+  const meta = `Canada’s next stat holiday is ${getMeta(nextHol)}. See all ${
+    holidays.length
+  } statutory holidays in Canada in ${year}.`
 
   return res.send(
     renderPage({
@@ -36,7 +36,8 @@ router.get('/', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, res) =>
         meta,
         path: req.path,
         region: 'Canada',
-        richSnippets: ['breadcrumb', 'speakable'],
+        year,
+        richSnippets: ['breadcrumb', 'dataset', 'speakable'],
       },
       props: { data: { holidays, nextHoliday: nextHol, year } },
     }),
@@ -53,7 +54,7 @@ router.get(
     // if the year value isn't in ALLOWED_YEARS, it will be caught by "checkYearErr"
     const year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
     const holidays = res.locals.rows
-    const meta = `See all statutory holidays in Canada in ${year}.`
+    const meta = `See all ${holidays.length} statutory holidays in Canada in ${year}.`
 
     return res.send(
       renderPage({
@@ -63,7 +64,8 @@ router.get(
           meta,
           path: req.path,
           region: 'Canada',
-          richSnippets: ['breadcrumb'],
+          year,
+          richSnippets: ['breadcrumb', 'dataset'],
         },
         props: { data: { holidays, nextHoliday: undefined, year } },
       }),
@@ -89,9 +91,9 @@ router.get(
       sourceEn,
     } = res.locals.rows[0]
 
-    const meta = `${provinceName}’s next stat holiday is ${getMeta(
-      nextHoliday,
-    )}. See all statutory holidays in ${provinceName}, Canada in ${year}.`
+    const meta = `${provinceName}’s next stat holiday is ${getMeta(nextHoliday)}. See all ${
+      holidays.length
+    } statutory holidays in ${provinceName}, Canada in ${year}.`
 
     return res.send(
       renderPage({
@@ -103,7 +105,8 @@ router.get(
           meta,
           path: req.path,
           region: provinceName,
-          richSnippets: ['breadcrumb', 'speakable'],
+          year,
+          richSnippets: ['breadcrumb', 'dataset', 'speakable'],
         },
         props: {
           data: {
@@ -137,7 +140,7 @@ router.get(
       sourceLink,
       sourceEn,
     } = res.locals.rows[0]
-    const meta = `See all statutory holidays in ${provinceName}, Canada in ${year}.`
+    const meta = `See all ${holidays.length} statutory holidays in ${provinceName}, Canada in ${year}.`
 
     return res.send(
       renderPage({
@@ -149,7 +152,8 @@ router.get(
           meta,
           path: req.path,
           region: provinceName,
-          richSnippets: ['breadcrumb'],
+          year,
+          richSnippets: ['breadcrumb', 'dataset'],
         },
         props: {
           data: {
@@ -178,9 +182,9 @@ router.get('/federal', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, 
   const holidays = res.locals.rows
   const nextHol = nextHoliday(holidays)
 
-  const meta = `Canada’s next federal stat holiday is ${getMeta(
-    nextHol,
-  )}. See all federal statutory holidays in Canada in ${year}.`
+  const meta = `Canada’s next federal stat holiday is ${getMeta(nextHol)}. See all ${
+    holidays.length
+  } federal statutory holidays in Canada in ${year}.`
 
   return res.send(
     renderPage({
@@ -190,7 +194,8 @@ router.get('/federal', checkRedirectYear, dbmw(getHolidaysWithProvinces), (req, 
         meta,
         path: req.path,
         region: 'Federal',
-        richSnippets: ['breadcrumb', 'speakable'],
+        year,
+        richSnippets: ['breadcrumb', 'dataset', 'speakable'],
       },
       props: {
         data: {
@@ -215,7 +220,7 @@ router.get(
     // if the year value isn't in ALLOWED_YEARS, it will be caught by "checkYearErr"
     const year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
     const holidays = res.locals.rows
-    const meta = `See all federal statutory holidays in Canada in ${year}.`
+    const meta = `See all ${holidays.length} federal statutory holidays in Canada in ${year}.`
 
     return res.send(
       renderPage({
@@ -225,7 +230,8 @@ router.get(
           meta,
           path: req.path,
           region: 'Federal',
-          richSnippets: ['breadcrumb'],
+          year,
+          richSnippets: ['breadcrumb', 'dataset'],
         },
         props: {
           data: { holidays, nextHoliday: undefined, federal: true, year, source: federalSource },

--- a/src/utils/richSnippets.js
+++ b/src/utils/richSnippets.js
@@ -1,4 +1,4 @@
-const breadcrumb = (region) => {
+const breadcrumb = ({ region }) => {
   const provinceBreadcrumb = {
     '@type': 'ListItem',
     position: 2,
@@ -41,7 +41,77 @@ const breadcrumb = (region) => {
   }
 }
 
-const speakable = (region, path) => {
+const dataset = ({ region, year, path, title, meta }) => {
+  const _getDescription = ({ path, meta }) => {
+    if (path === '/') {
+      return 'Returns all 28 Canadian public holidays for all 13 provinces and territories in Canada, including federal holidays.'
+    }
+
+    return meta.includes('next') ? meta.split('. ').pop() : meta
+  }
+
+  const _getICSUrl = ({ path, year }) => {
+    const baseUrl = 'https://canada-holidays.ca/ics'
+
+    if (path === '/') return `${baseUrl}/${year}`
+    let _path = path.startsWith('/province') ? path.substring(9) : path
+
+    return `https://canada-holidays.ca/ics${_path}${_path.endsWith(year) ? '' : `/${year}`}`
+  }
+
+  const _getJSONUrl = ({ path, year }) => {
+    const baseUrl = 'https://canada-holidays.ca/api/v1'
+
+    if (path === '/' || path === `/${year}`) return `${baseUrl}/holidays?year=${year}`
+    if (path.includes('federal')) {
+      return `${baseUrl}/holidays?year=${year}&federal=true`
+    }
+
+    if (path.includes('province')) {
+      return `${baseUrl}/provinces/${path.split('/')[2]}?year=${year}`
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(`no JSON URL for ${path}`)
+    return ''
+  }
+
+  return {
+    '@context': 'https://schema.org/',
+    '@type': 'Dataset',
+    name: title.split('—')[0].trim(),
+    description: _getDescription({ path, meta }),
+    url: `https://canada-holidays.ca${path}`,
+    alternateName: ['Canada Holidays API'],
+    creator: [
+      {
+        '@type': 'Person',
+        givenName: 'Paul',
+        familyName: 'Craig',
+        name: 'Paul Craig',
+        email: 'paul@pcraig3.ca',
+        url: 'https://pcraig3.ca',
+      },
+    ],
+    license: 'https://opensource.org/licenses/MIT',
+    spatialCoverage: region === 'Canada' || region === 'Federal' ? 'Canada' : `${region}, Canada`,
+    temporalCoverage: `${year}`,
+    distribution: [
+      {
+        '@type': 'DataDownload',
+        encodingFormat: 'iCalendar',
+        contentUrl: _getICSUrl({ path, year }),
+      },
+      {
+        '@type': 'DataDownload',
+        encodingFormat: 'JSON',
+        contentUrl: _getJSONUrl({ path, year }),
+      },
+    ],
+  }
+}
+
+const speakable = ({ region, path }) => {
   const name =
     region === 'Federal'
       ? 'Canada’s next federal holiday'
@@ -61,5 +131,6 @@ const speakable = (region, path) => {
 
 module.exports = {
   breadcrumb,
+  dataset,
   speakable,
 }


### PR DESCRIPTION
Added dataset metadata to the <head> of pages for provincial, federal, and national holidays.

Also updated the meth descriptions on those pages to mention the number of holidays there are.

As always, bump version.

Sources:
- https://developers.google.com/search/docs/data-types/dataset
  - eg, https://datasetsearch.research.google.com/search?query=holidays%20canada&docid=Ikqkxk%2BCzNTbfLGfAAAAAA%3D%3D