### PR TITLE
Fix tiny a11y bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.1] - 2020-10-26
+
+### Fixed
+
+- rel="noopener" for target=_blank links offsite
+- add cloudflare beacon script to CSP
+- a11y: no tabbed focus on the date in the header
+
 ## [2.12.0] - 2020-10-26
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # TODO
 
-- rel no-opener: https://web.dev/external-anchors-use-rel-noopener/
 - Change province urls to provinces to match API (so dumb)
 - add next/previous links at the bottom
 - guess location?
@@ -13,7 +12,8 @@
 
 # DONE
 
-- don't focus on aria-hidden date in header
+- bug: rel no-opener
+- bug: don't focus on aria-hidden date in header
 - make screen reader improvements for the "next holidays" page
 - add google rich results 💰
   - breadcrumbs

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO
 
+- rel no-opener: https://web.dev/external-anchors-use-rel-noopener/
 - Change province urls to provinces to match API (so dumb)
 - add next/previous links at the bottom
 - guess location?
@@ -12,6 +13,7 @@
 
 # DONE
 
+- don't focus on aria-hidden date in header
 - make screen reader improvements for the "next holidays" page
 - add google rich results 💰
   - breadcrumbs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/NextHoliday.js
+++ b/src/components/NextHoliday.js
@@ -18,7 +18,7 @@ const NextHoliday = ({ nextHoliday, provinceName = 'Canada', federal }) => {
           ${' '}next${' '}${federal && 'federal '}holiday${' '.replace(/ /, '\u00a0')}is
         </div>
         <div class="h1--lg">
-          <a href="#next-holiday-row"
+          <a href="#next-holiday-row" tabindex="-1"
             ><${DateHtml} data-event="true" data-action="next-holidays-row-link"
             data-label=${`next-holidays-row-link-${
               federal ? 'federal' : provinceName.replace(/\s+/g, '-').toLowerCase()

--- a/src/config/csp.config.js
+++ b/src/config/csp.config.js
@@ -14,6 +14,7 @@ module.exports = {
     "'sha256-Wezgm/yRorRVzqbr6vDdLOJEGKDTVKRuWZ2Yh53e/EU='",
     "'sha256-/PhlWtWSFKGpnQswrM5AJwZ6WsgKO5Bn3J8jgWZfT4Q='",
     'https://www.google-analytics.com',
+    'https://static.cloudflareinsights.com/beacon.min.js',
   ],
   styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
 }

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -63,7 +63,9 @@ const API = () =>
           <ul>
             <li>It’s free (<span aria-hidden="true">✨</span>)</li>
             <li>
-              <a href="https://twitter.com/pcraig3" target="_blank">Dedicated support channel</a>
+              <a href="https://twitter.com/pcraig3" target="_blank" rel="noopener"
+                >Dedicated support channel</a
+              >
             </li>
             <li>Kind of bilingual (EN & FR)</li>
             <li>
@@ -75,13 +77,16 @@ const API = () =>
               >${' '} (heck yes <span aria-hidden="true">🤙</span>)
             </li>
             <li>
-              <a href="https://github.com/pcraig3/hols" target="_blank">Open source</a> which is
-              cool if you’re a nerd
+              <a href="https://github.com/pcraig3/hols" target="_blank" rel="noopener"
+                >Open source</a
+              >
+              which is cool if you’re a nerd
             </li>
             <li>
               <a
                 href="https://github.com/pcraig3/hols/blob/main/reference/Canada-Holidays-API.v1.yaml"
                 target="_blank"
+                rel="noopener"
                 >Documented with an OpenAPI spec</a
               >${' '}which is <em>even more</em> cool for <em>even nerdier</em> nerds
             </li>
@@ -94,10 +99,12 @@ const API = () =>
           There's an OpenAPI spec at${' '}<a
             href="https://github.com/pcraig3/hols/blob/main/reference/Canada-Holidays-API.v1.yaml"
             target="_blank"
+            rel="noopener"
             ><code>Canada-Holidays-API.v1.yaml</code></a
           >${' '}and a${' '}<a
             href="https://app.swaggerhub.com/apis/pcraig3/canada-holidays/"
             target="_blank"
+            rel="noopener"
             >SwaggerHub</a
           >${' '}page where you can test the endpoints.
         </p>
@@ -106,6 +113,7 @@ const API = () =>
             title="API documentation"
             href="https://github.com/pcraig3/hols/blob/main/API.md"
             target="_blank"
+            rel="noopener"
             >basic overview on GitHub</a
           >
           ${' '}if you’re a “read-the-first-and-last-chapter” kind of person.

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -28,10 +28,18 @@ const About = ({ data: { nextHoliday } }) =>
         <h2>Me</h2>
         <p>
           Hello, my name is${' '}
-          <a class="pcraig3" href="https://pcraig3.ca" title="Paul Craig" target="_blank">Paul</a
+          <a
+            class="pcraig3"
+            href="https://pcraig3.ca"
+            title="Paul Craig"
+            target="_blank"
+            rel="noopener"
+            >Paul</a
           >${' '} and I am paying for this site for some reason.${' '}
-          <a href="https://github.com/pcraig3/hols" target="_blank">Code is on GitHub</a> if you
-          want to “borrow” all my intellectual property.
+          <a href="https://github.com/pcraig3/hols" target="_blank" rel="noopener"
+            >Code is on GitHub</a
+          >
+          if you want to “borrow” all my intellectual property.
         </p>
       <//>
     <//>

--- a/src/pages/FederallyRegulated.js
+++ b/src/pages/FederallyRegulated.js
@@ -43,6 +43,7 @@ const FederallyRegulated = () =>
             href="https://www.canada.ca/en/employment-social-development/programs/employment-equity/regulated-industries.html"
             title="the list of Federally Regulated Businesses and Industries"
             target="_blank"
+            rel="noopener"
             >the full list</a
           >.
         </p>
@@ -52,9 +53,7 @@ const FederallyRegulated = () =>
           Sometimes, provincial holidays are the same as federal holidays — like Christmas, or New
           Year’s — but not always.
         </p>
-        <p>
-          For example, the province of Ontario doesn’t observe Remembrance Day, which means
-        </p>
+        <p>For example, the province of Ontario doesn’t observe Remembrance Day, which means</p>
         <ul>
           <li>on November 11, post offices are closed but schools are open</li>
         </ul>
@@ -63,9 +62,7 @@ const FederallyRegulated = () =>
           However, Ontario observes Family Day but the federal government doesn’t. So that means
         </p>
         <ul>
-          <li>
-            on the third Monday in February, schools are closed but post offices will be open
-          </li>
+          <li>on the third Monday in February, schools are closed but post offices will be open</li>
         </ul>
 
         <h2>How can I tell which holidays apply to me?</h2>
@@ -75,6 +72,7 @@ const FederallyRegulated = () =>
           <a
             href="https://www.canada.ca/en/employment-social-development/programs/employment-equity/regulated-industries.html"
             target="_blank"
+            rel="noopener"
             >the list of federally regulated industries</a
           >.
         </p>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -207,6 +207,7 @@ const Province = ({
                     >Source:${' '}<a
                       href=${source.link}
                       target="_blank"
+                      rel="noopener"
                       data-event="true"
                       data-action="source-link"
                       data-label=${`source-link-${provinceIdOrFederal || 'canada'}`}

--- a/src/pages/Provinces.js
+++ b/src/pages/Provinces.js
@@ -58,6 +58,7 @@ const Provinces = ({ data }) =>
                 <a
                   href="https://www.canada.ca/en/employment-social-development/programs/employment-equity/regulated-industries.html"
                   target="_blank"
+                  rel="noopener"
                   >federally-regulated industries</a
                 >
                 ${' '}observe federal holidays instead of provincial holidays.
@@ -72,7 +73,7 @@ const Provinces = ({ data }) =>
         </div>
         <ul>
           ${data.provinces.map(
-            province => html`
+            (province) => html`
               <li><a href=${`/province/${province.id}`}>${province.nameEn}</a></li>
             `,
           )}

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -30,7 +30,7 @@ const createRows = ({ provinces }) => {
     return {
       key: html`<a href="/province/${p.id}">${p.nameEn}</a>`,
       value: html`<span class="external-link"
-        ><a href="${p.sourceLink}" target="_blank">${p.sourceEn}<${External} /></a
+        ><a href="${p.sourceLink}" target="_blank" rel="noopener">${p.sourceEn}<${External} /></a
       ></span>`,
       className: summaryTableStyles,
     }
@@ -59,6 +59,7 @@ const AddHolidays = ({ data: { provinces } }) => {
                 ><a
                   href="https://www.tpsgc-pwgsc.gc.ca/remuneration-compensation/services-paye-pay-services/paye-information-pay/vie-life/vie-conge-life-leave/conge-paye-holiday-pay-eng.html"
                   target="_blank"
+                  rel="noopener"
                   >Statutory holiday pay, Canada.ca<${External} /></a
               ></span>`,
               className: summaryTableStyles,
@@ -66,16 +67,12 @@ const AddHolidays = ({ data: { provinces } }) => {
           ]}
         >
           <h2>Federally-regulated industries</h2>
-          <p>
-            11 holidays a year, plus Friday afternoons.
-          </p>
+          <p>11 holidays a year, plus Friday afternoons.</p>
         <//>
 
         <${SummaryTable} title="Provinces and territories" rows=${createRows({ provinces })}>
           <h2>Provinces and territories</h2>
-          <p>
-            Made in Canada, assembled by hand in Ottawa.
-          </p>
+          <p>Made in Canada, assembled by hand in Ottawa.</p>
         <//>
 
         <h2 id="legislation" tabindex="-1">Public holiday legislation</h2>
@@ -85,6 +82,7 @@ const AddHolidays = ({ data: { provinces } }) => {
             href="https://github.com/pcraig3/hols#citations"
             title="Sources (including legislation) on Github"
             target="_blank"
+            rel="noopener"
             data-event="true"
             data-action="all-sources-link"
             data-label="all-sources-link-canada"


### PR DESCRIPTION
This PR does a few very small fixes:

1. add rel="noopener" attributes to target="_blank" links that go offsite
2. hides tabbed focus from the date at the top
3. allows a cloudflare thing through the CSP