### PR TITLE
add link to next year's holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2020-11-03
+
+### Added
+
+- add link to next year's holidays to all years but the current max (2022)
+  - not putting "past holidays" because nobody wants them
+
 ## [2.12.1] - 2020-10-26
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - Service worker offline page?
 - Change province urls to provinces to match API (so dumb)
-- add next/previous links at the bottom
 - guess location?
 - figure out about optional holidays
 - Add years to dates on years pages?
@@ -13,6 +12,7 @@
 
 # DONE
 
+- add next year links at the bottom
 - bug: rel no-opener
 - bug: don't focus on aria-hidden date in header
 - make screen reader improvements for the "next holidays" page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/NextYearLink.js
+++ b/src/components/NextYearLink.js
@@ -1,0 +1,41 @@
+const { html } = require('../utils')
+const { css } = require('emotion')
+const { theme } = require('../styles')
+
+const styles = css`
+  font-weight: 700;
+  margin-top: -${theme.space.xxl};
+  margin-bottom: calc(${theme.space.xl} + ${theme.space.xl});
+  padding-bottom: ${theme.space.md};
+  text-align: left;
+  border-bottom: 2px solid ${theme.color.greyLight};
+
+  @media (${theme.mq.md}) {
+    text-align: center;
+  }
+`
+
+const getLink = ({ provinceId, year, federal }) => {
+  const nextYear = year + 1
+  if (provinceId) return `/province/${provinceId}/${nextYear}`
+  if (federal) return `/federal/${nextYear}`
+  return `/${nextYear}`
+}
+
+const NextYearLink = ({ provinceName, provinceId, year, federal }) => {
+  return html`
+    <div class=${styles}>
+      <a
+        href=${getLink({ provinceId, year, federal })}
+        class="right-arrow"
+        data-event="true"
+        data-action="source-link"
+        data-label=${`source-link-${provinceId || federal ? 'federal' : 'canada'}`}
+        >${federal ? 'Federal' : provinceName}${' '}
+        <span class="visuallyHidden">statutory</span>${' '}holidays in ${year + 1}</a
+      >
+    </div>
+  `
+}
+
+module.exports = NextYearLink

--- a/src/components/NextYearLink.js
+++ b/src/components/NextYearLink.js
@@ -27,7 +27,7 @@ const NextYearLink = ({ provinceName, provinceId, year, federal }) => {
     <div class=${styles}>
       <a
         href=${getLink({ provinceId, year, federal })}
-        class="right-arrow"
+        class="link__next-year right-arrow"
         data-event="true"
         data-action="source-link"
         data-label=${`source-link-${provinceId || federal ? 'federal' : 'canada'}`}

--- a/src/components/__tests__/NextYearLink.test.js
+++ b/src/components/__tests__/NextYearLink.test.js
@@ -1,0 +1,52 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils')
+
+const NextYearLink = require('../NextYearLink.js')
+
+const renderNextYearLink = (props = {}) => {
+  return cheerio.load(render(html` <${NextYearLink} ...${props} //> `))
+}
+
+test('NextYearLink displays properly', () => {
+  const $ = renderNextYearLink({ provinceName: 'Canada', year: 2020 })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Canada statutory holidays in 2021')
+  expect($('a').attr('href')).toEqual('/2021')
+})
+
+test('NextYearLink displays federal text properly', () => {
+  const $ = renderNextYearLink({ provinceName: 'Canada', year: 2020, federal: true })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Federal statutory holidays in 2021')
+  expect($('a').attr('href')).toEqual('/federal/2021')
+})
+
+test('NextYearLink displays provincial text properly', () => {
+  const $ = renderNextYearLink({ provinceName: 'Manitoba', provinceId: 'MB', year: 2020 })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Manitoba statutory holidays in 2021')
+  expect($('a').attr('href')).toEqual('/province/MB/2021')
+})
+
+test('NextYearLink displays future link and text properly', () => {
+  const $ = renderNextYearLink({ provinceName: 'Canada', year: 2021 })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Canada statutory holidays in 2022')
+  expect($('a').attr('href')).toEqual('/2022')
+})
+
+test('NextYearLink displays past link and text properly', () => {
+  const $ = renderNextYearLink({ provinceName: 'Canada', year: 2018, federal: true })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Federal statutory holidays in 2019')
+  expect($('a').attr('href')).toEqual('/federal/2019')
+})
+
+// the component doesn't know anything about dates: it just adds one to the year integer
+test('NextYearLink displays VERY future link and text properly', () => {
+  const $ = renderNextYearLink({ provinceName: 'Nova Scotia', provinceId: 'NS', year: 5000 })
+  expect($('a').length).toBe(1)
+  expect($('a').text()).toEqual('Nova Scotia statutory holidays in 5001')
+  expect($('a').attr('href')).toEqual('/province/NS/5001')
+})

--- a/src/components/__tests__/SkipLink.test.js
+++ b/src/components/__tests__/SkipLink.test.js
@@ -5,14 +5,7 @@ const { html } = require('../../utils')
 const SkipLink = require('../SkipLink.js')
 
 test('SkipLink displays link properly', () => {
-  expect(1).toBe(1)
-  const $ = cheerio.load(
-    render(
-      html`
-        <${SkipLink} //>
-      `,
-    ),
-  )
+  const $ = cheerio.load(render(html` <${SkipLink} //> `))
   expect($('a').length).toBe(1)
   expect($('a').text()).toEqual('Skip to main content')
   expect($('a').attr('href')).toEqual('#content')

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -1,6 +1,7 @@
 const { css } = require('emotion')
 const { html, pe2pei, getProvinceIdOrFederalString } = require('../utils')
 const { theme, horizontalPadding, insideContainer } = require('../styles')
+const { ALLOWED_YEARS } = require('../config/vars.config')
 const Layout = require('../components/Layout.js')
 const DateHtml = require('../components/DateHtml.js')
 const NextHolidayBox = require('../components/NextHolidayBox.js')
@@ -202,7 +203,7 @@ const Province = ({
                 </div>
               </div>`}
             <//>
-            ${year < 2022 &&
+            ${year < ALLOWED_YEARS[ALLOWED_YEARS.length - 1] &&
             html`<${NextYearLink}
               provinceName=${provinceName}
               provinceId=${provinceId}

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -7,6 +7,7 @@ const NextHolidayBox = require('../components/NextHolidayBox.js')
 const ProvincePicker = require('../components/ProvincePicker.js')
 const SummaryTable = require('../components/SummaryTable.js')
 const CalButton = require('../components/CalButton.js')
+const NextYearLink = require('../components/NextYearLink.js')
 const { External } = require('../components/Svg.js')
 
 const styles = ({ accent = theme.color.red } = {}) => css`
@@ -201,6 +202,13 @@ const Province = ({
                 </div>
               </div>`}
             <//>
+            ${year < 2022 &&
+            html`<${NextYearLink}
+              provinceName=${provinceName}
+              provinceId=${provinceId}
+              federal=${federal}
+              year=${year}
+            />`}
             <div class="bottom-link__container with-source">
               ${source
                 ? html`<span class="bottom-link external-link"

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -8,22 +8,24 @@ const getProvince = () => {
   return { id: 'NL', nameEn: 'Newfoundland and Labrador' }
 }
 
-const getNextHoliday = () => {
+const getNextHoliday = (year = 2020) => {
   return {
     id: 27,
-    observedDate: '2020-12-28',
+    observedDate: `${year}-12-28`,
     nameEn: 'Boxing Day',
     federal: 1,
     provinces: [getProvince()],
   }
 }
 
-const renderPage = () => {
-  const _nextHoliday = getNextHoliday()
+const renderPage = (year) => {
+  const _nextHoliday = getNextHoliday(year)
   return cheerio.load(
     render(
       html`
-        <${Province} ...${{ data: { nextHoliday: _nextHoliday, holidays: [_nextHoliday] } }} />
+        <${Province}
+          ...${{ data: { nextHoliday: _nextHoliday, holidays: [_nextHoliday], year } }}
+        />
       `,
     ),
   )
@@ -38,11 +40,23 @@ describe('Province page', () => {
     expect($('h2').text()).toEqual('Canada statutory holidays in 2020')
     // check the data label is lowercasing the province name
     expect($('.h1--lg a time').attr('data-label')).toEqual('next-holidays-row-link-canada')
+    // check that the link to next year's holidays is visible
+    expect($('a.link__next-year').text()).toEqual('Canada statutory holidays in 2021')
   })
 
   test('renders #next-holiday-row id', () => {
     const $ = renderPage()
     expect($('h2#holidays-table').text()).toBe('Canada statutory holidays in 2020')
     expect($('#next-holiday-row').text()).toBe(' December 28, Monday Boxing DayFederal holiday, NL')
+  })
+
+  test('does not render next year link', () => {
+    const $ = renderPage(2022)
+    expect($('h1').length).toBe(1)
+    expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 28Boxing Day')
+    expect($('h2').length).toBe(1)
+    expect($('h2').text()).toEqual('Canada statutory holidays in 2022')
+    // check that the link to next year's holidays is NOT visible
+    expect($('a.link__next-year').length).toBe(0)
   })
 })


### PR DESCRIPTION
- add link to next year's holidays to all years but the current max (2022)
  - not putting "past holidays" because nobody wants them

## Screenshots 

| before | after |
|--------|-------|
|    end of holidays for the year, the end    | end of holidays for the year, link to next year      |
|  <img width="1284" alt="Screen Shot 2020-11-03 at 3 38 34 AM" src="https://user-images.githubusercontent.com/2454380/97964098-3495fc80-1d86-11eb-89f8-aedaa3e08ae8.png">   |  <img width="1284" alt="Screen Shot 2020-11-03 at 3 38 27 AM" src="https://user-images.githubusercontent.com/2454380/97964111-3790ed00-1d86-11eb-9d00-b349a478e799.png">  |



