### PR TITLE
Change `/province` URLs to `/provinces`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2020-11-17
+
+### Breaking change
+
+- Moved all the `/province/*` URLs to `/provinces/*`
+  - eg, `/province/MB/2021` is now `/provinces/MB/2021`
+  - old URLs will 301 redirect to the new URLs
+  - technically this is a breaking change, although I am more worried about search engines than actual users
+
+### Added
+
+- added a rel="canonical" link to the `<head>`
+
 ## [2.14.3] - 2020-11-16
 
 ### Fixed
@@ -66,7 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Added holidays count to the meta string for each region.
-
 
 ## [2.11.1] - 2020-10-21
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 - Service worker offline page?
-- Change province urls to provinces to match API (so dumb)
 - guess location?
 - figure out about optional holidays
 - Add years to dates on years pages?
@@ -12,6 +11,7 @@
 
 # DONE
 
+- Change province urls to provinces to match API (so dumb that this happened)
 - download link/button has nicer calendar icon
 - add opengraph images
   - shorten opengraph descriptions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.14.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "2.14.3",
+  "version": "3.0.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,481 +8,301 @@
 
 <url>
   <loc>https://canada-holidays.ca/</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
   <loc>https://canada-holidays.ca/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
+  <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/federal/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/federal/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
   <loc>https://canada-holidays.ca/federal/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
+  <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/api</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/add-holidays-to-calendar</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/AB</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/AB</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/AB/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/AB/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/AB/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/AB/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/AB/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/AB/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/BC</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/BC</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/BC/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/BC/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/BC/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/BC/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/BC/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/BC/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NB</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NB</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NB/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NB/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NB/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NB/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NB/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NB/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/ON</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/ON</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/ON/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/ON/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/ON/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/ON/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/ON/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/ON/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/SK</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/SK</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/SK/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/SK/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
+  <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/SK/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/SK/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/SK/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/SK/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/MB</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/MB</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/MB/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/MB/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/MB/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/MB/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/MB/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/MB/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/PE</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/PE</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/PE/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/PE/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/PE/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/PE/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/PE/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/PE/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NS</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NS</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NS/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NS/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NS/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NS/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NS/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NS/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NL</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NL</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NL/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NL/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NL/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NL/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NL/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NL/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/QC</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/QC</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/QC/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/QC/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/QC/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/QC/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/QC/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/QC/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NT</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NT</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NT/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NT/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NT/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NT/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NT/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NT/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NU</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NU</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NU/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/NU/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NU/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/NU/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NU/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/NU/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/YT</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/YT</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/YT/2018</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/YT/2021</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
+  <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://canada-holidays.ca/province/YT/2019</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/YT/2021</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://canada-holidays.ca/province/YT/2022</loc>
-  <lastmod>2020-10-26T05:16:48+00:00</lastmod>
+  <loc>https://canada-holidays.ca/provinces/YT/2022</loc>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/do-federal-holidays-apply-to-me</loc>
-  <lastmod>2020-06-04T06:50:47+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/sources</loc>
-  <lastmod>2020-07-03T01:49:32+00:00</lastmod>
+  <lastmod>2020-11-17T17:21:50+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>

--- a/src/__tests__/server.test.js
+++ b/src/__tests__/server.test.js
@@ -11,7 +11,7 @@ describe('Test server responses', () => {
       // Update db schema to the latest version using SQL-based migrations
       .then(() => db.migrate()) // <=
       // Display error message if something went wrong
-      .catch(err => console.error(err.stack)) // eslint-disable-line no-console
+      .catch((err) => console.error(err.stack)) // eslint-disable-line no-console
   })
 
   afterAll(() => {

--- a/src/components/NextYearLink.js
+++ b/src/components/NextYearLink.js
@@ -17,7 +17,7 @@ const styles = css`
 
 const getLink = ({ provinceId, year, federal }) => {
   const nextYear = year + 1
-  if (provinceId) return `/province/${provinceId}/${nextYear}`
+  if (provinceId) return `/provinces/${provinceId}/${nextYear}`
   if (federal) return `/federal/${nextYear}`
   return `/${nextYear}`
 }

--- a/src/components/ObservingProvinces.js
+++ b/src/components/ObservingProvinces.js
@@ -18,14 +18,14 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
     return federal
       ? html`
           <p>
-            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+            Observed in${' '}<a href=${`/provinces/${provinces[0].id}`}>${provinces[0].nameEn}</a>
             ${' '}and by${' '}<a href="/federal">federal industries</a>
             <span class="visuallyHidden">.</span>
           </p>
         `
       : html`
           <p>
-            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+            Observed in${' '}<a href=${`/provinces/${provinces[0].id}`}>${provinces[0].nameEn}</a>
             <span class="visuallyHidden">.</span>
           </p>
         `
@@ -35,16 +35,16 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
     return federal
       ? html`
           <p>
-            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>,
-            ${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn},</a>${' '}and
+            Observed in${' '}<a href=${`/provinces/${provinces[0].id}`}>${provinces[0].nameEn}</a>,
+            ${' '}<a href=${`/provinces/${provinces[1].id}`}>${provinces[1].nameEn},</a>${' '}and
             ${' '}by${' '}<a href="/federal">federal industries</a>
             <span class="visuallyHidden">.</span>
           </p>
         `
       : html`
           <p>
-            Observed in${' '}<a href=${`/province/${provinces[0].id}`}>${provinces[0].nameEn}</a>
-            ${' '}and${' '}<a href=${`/province/${provinces[1].id}`}>${provinces[1].nameEn}</a>
+            Observed in${' '}<a href=${`/provinces/${provinces[0].id}`}>${provinces[0].nameEn}</a>
+            ${' '}and${' '}<a href=${`/provinces/${provinces[1].id}`}>${provinces[1].nameEn}</a>
             <span class="visuallyHidden">.</span>
           </p>
         `
@@ -58,7 +58,7 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
         Observed in
         ${provinces.map(
           (p) =>
-            html`${' '}<a href=${`/province/${p.id}`} aria-label=${p.nameEn}>${pe2pei(p.id)}</a
+            html`${' '}<a href=${`/provinces/${p.id}`} aria-label=${p.nameEn}>${pe2pei(p.id)}</a
               >${','}`,
         )}
         ${' '}and by${' '}<a href="/federal">federal industries</a>
@@ -72,7 +72,7 @@ const ObservingProvinces = ({ provinces = [], federal = false }) => {
       Observed in
       ${provinces.map(
         (p) => html`
-          ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/province/${p.id}`} aria-label=${p.nameEn}
+          ${isLastProvince(p) ? ' and ' : ' '}<a href=${`/provinces/${p.id}`} aria-label=${p.nameEn}
             >${pe2pei(p.id)}</a
           >${isLastProvince(p) ? '' : ','}
         `,

--- a/src/components/__tests__/NextYearLink.test.js
+++ b/src/components/__tests__/NextYearLink.test.js
@@ -28,7 +28,7 @@ test('NextYearLink displays provincial text properly', () => {
   const $ = renderNextYearLink({ provinceName: 'Manitoba', provinceId: 'MB', year: 2020 })
   expect($('a').length).toBe(1)
   expect($('a').text()).toEqual('Manitoba statutory holidays in 2021')
-  expect($('a').attr('href')).toEqual('/province/MB/2021')
+  expect($('a').attr('href')).toEqual('/provinces/MB/2021')
   expect($('a').attr('data-label')).toEqual('next-year-MB')
 })
 
@@ -53,6 +53,6 @@ test('NextYearLink displays VERY future link and text properly', () => {
   const $ = renderNextYearLink({ provinceName: 'Nova Scotia', provinceId: 'NS', year: 5000 })
   expect($('a').length).toBe(1)
   expect($('a').text()).toEqual('Nova Scotia statutory holidays in 5001')
-  expect($('a').attr('href')).toEqual('/province/NS/5001')
+  expect($('a').attr('href')).toEqual('/provinces/NS/5001')
   expect($('a').attr('data-label')).toEqual('next-year-NS')
 })

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -112,7 +112,7 @@ const createRows = (holidays, federal, isCurrentYear) => {
     let provincesHTML = holiday.provinces.map(
       (p, i) =>
         html`
-          <a href="/province/${p.id}" title="Holidays for ${p.nameEn}">${pe2pei(p.id)}</a>${i +
+          <a href="/provinces/${p.id}" title="Holidays for ${p.nameEn}">${pe2pei(p.id)}</a>${i +
             1 ===
           holiday.provinces.length
             ? ''

--- a/src/pages/Provinces.js
+++ b/src/pages/Provinces.js
@@ -74,7 +74,7 @@ const Provinces = ({ data }) =>
         <ul>
           ${data.provinces.map(
             (province) => html`
-              <li><a href=${`/province/${province.id}`}>${province.nameEn}</a></li>
+              <li><a href=${`/provinces/${province.id}`}>${province.nameEn}</a></li>
             `,
           )}
         </ul>

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -28,7 +28,7 @@ const summaryTableStyles = css`
 const createRows = ({ provinces }) => {
   return provinces.map((p) => {
     return {
-      key: html`<a href="/province/${p.id}">${p.nameEn}</a>`,
+      key: html`<a href="/provinces/${p.id}">${p.nameEn}</a>`,
       value: html`<span class="external-link"
         ><a href="${p.sourceLink}" target="_blank" rel="noopener">${p.sourceEn}<${External} /></a
       ></span>`,

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -5,7 +5,11 @@ const { breadcrumb, dataset, speakable } = require('../utils/richSnippets')
 const { theme, visuallyHidden } = require('../styles')
 const { fontStyles, printStyles, ga } = require('../headStyles')
 
-const document = ({ title, content, docProps: { id, meta, path, region, richSnippets, year } }) => {
+const document = ({
+  title,
+  content,
+  docProps: { id, meta, path, region, richSnippets, year, error },
+}) => {
   return `
     <!DOCTYPE html>
     <html lang="en" id="html">
@@ -14,6 +18,7 @@ const document = ({ title, content, docProps: { id, meta, path, region, richSnip
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="${meta ? meta : 'Upcoming statutory holidays in Canada'}">
+        ${!error ? `<link rel="canonical" href="https://canada-holidays.ca${path}" />` : ''}
 
         <!-- open graph tags -->
         <meta property="og:type" content="website" />

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -72,7 +72,7 @@ describe('Test ics responses', () => {
         test(`it should return 302 for unsupported year "/ics/${path}/${badYear}"`, async () => {
           const response = await request(app).get(`/ics/${path}/${badYear}`)
           expect(response.statusCode).toBe(302)
-          const expectedPath = path && path !== 'federal' ? `/province/${path}` : `/${path}`
+          const expectedPath = path && path !== 'federal' ? `/provinces/${path}` : `/${path}`
           expect(response.headers.location).toBe(expectedPath)
         })
       })

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -93,21 +93,21 @@ describe('Test ui responses', () => {
           expect(response.headers.location).toBe('/federal')
         })
 
-        test('it should return 302 to /province/:id for a good param', async () => {
+        test('it should return 302 to /provinces/:id for a good param', async () => {
           const response = await request(app).post('/provinces').send({ region: 'AB' })
           expect(response.statusCode).toBe(302)
-          expect(response.headers.location).toBe('/province/AB')
+          expect(response.headers.location).toBe('/provinces/AB')
         })
 
         const params = [
-          { region: 'AB', url: '/province/AB' },
-          { region: 'ab', url: '/province/AB' },
-          { region: 'Alberta', url: '/province/AL' },
-          { region: 'a', url: '/province/A' },
-          { region: '<script>', url: '/province/%3CS' },
-          { region: 'https://evil.org', url: '/province/HT' },
-          { region: 'false', url: '/province/FA' },
-          { region: '1', url: '/province/1' },
+          { region: 'AB', url: '/provinces/AB' },
+          { region: 'ab', url: '/provinces/AB' },
+          { region: 'Alberta', url: '/provinces/AL' },
+          { region: 'a', url: '/provinces/A' },
+          { region: '<script>', url: '/provinces/%3CS' },
+          { region: 'https://evil.org', url: '/provinces/HT' },
+          { region: 'false', url: '/provinces/FA' },
+          { region: '1', url: '/provinces/1' },
         ]
         params.map((p) => {
           test(`it should return 302 to ${p.url} uppercased for param: '${p.region}'`, async () => {
@@ -144,13 +144,13 @@ describe('Test ui responses', () => {
 
         describe('for param "region" AND param "year"', () => {
           const params = [
-            { region: 'AB', year: '1000', url: '/province/AB' },
+            { region: 'AB', year: '1000', url: '/provinces/AB' },
             { region: 'federal', year: '1000', url: '/federal' },
             { region: '', year: '1000', url: '/' },
-            { region: 'AB', year: '2021', url: '/province/AB/2021' },
+            { region: 'AB', year: '2021', url: '/provinces/AB/2021' },
             { region: 'federal', year: '2021', url: '/federal/2021' },
             { region: '', year: '2021', url: '/2021' },
-            { region: 'AB', year: '2020', url: '/province/AB' },
+            { region: 'AB', year: '2020', url: '/provinces/AB' },
             { region: 'federal', year: '2020', url: '/federal' },
             { region: '', year: '2020', url: '/' },
           ]
@@ -168,15 +168,15 @@ describe('Test ui responses', () => {
     })
   })
 
-  describe('Test /province/:provinceId responses', () => {
+  describe('Test /provinces/:provinceId responses', () => {
     describe('for a good provinceId', () => {
       test('it should return 200', async () => {
-        const response = await request(app).get('/province/MB')
+        const response = await request(app).get('/provinces/MB')
         expect(response.statusCode).toBe(200)
       })
 
       test('it should return the h1, title, and meta tag', async () => {
-        const response = await request(app).get('/province/MB')
+        const response = await request(app).get('/provinces/MB')
         const $ = cheerio.load(response.text)
         expect($('h1 .visible').text()).toMatch(/^Manitoba’s next holiday\u00a0is/)
         expect($('title').text()).toEqual(
@@ -191,17 +191,23 @@ describe('Test ui responses', () => {
       })
     })
 
-    describe('Test /province/PEI response', () => {
+    describe('Test /provinces/PEI response', () => {
       test('it should return 301', async () => {
-        const response = await request(app).get('/province/PEI')
+        const response = await request(app).get('/provinces/PEI')
         expect(response.statusCode).toBe(301)
-        expect(response.headers.location).toEqual('/province/PE')
+        expect(response.headers.location).toEqual('/provinces/PE')
+      })
+
+      test('it should return 301 with the year included', async () => {
+        const response = await request(app).get('/provinces/PEI/2022')
+        expect(response.statusCode).toBe(301)
+        expect(response.headers.location).toEqual('/provinces/PE/2022')
       })
     })
 
-    describe('Test /province/:provinceId/:year responses', () => {
+    describe('Test /provinces/:provinceId/:year responses', () => {
       test('it should return the h1, title, and meta tag for MB in 2021', async () => {
-        const response = await request(app).get('/province/MB/2021')
+        const response = await request(app).get('/provinces/MB/2021')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Manitobastatutory Holidays in 2021')
         expect($('title').text()).toEqual(
@@ -243,7 +249,7 @@ describe('Test ui responses', () => {
     })
 
     describe('Test /*/:year responses', () => {
-      const URLS = ['', '/federal', '/province/MB']
+      const URLS = ['', '/federal', '/provinces/MB']
       URLS.map((url) => {
         describe('for a good year', () => {
           GOOD_YEARS.map((year) => {
@@ -428,7 +434,7 @@ describe('Test ui responses', () => {
             ? `and an invalid year ("${yearPath}") `
             : `and a good year ("${yearPath}") `
         }it should return the h1, title, and meta tag`, async () => {
-          const response = await request(app).get(`/province/pangea${yearPath}`)
+          const response = await request(app).get(`/provinces/pangea${yearPath}`)
           const $ = cheerio.load(response.text)
           expect($('h1').text()).toEqual('400')
           expect($('p').text()).toEqual(
@@ -441,7 +447,7 @@ describe('Test ui responses', () => {
         })
       })
       test('it should return the h1, title, and meta tag', async () => {
-        const response = await request(app).get('/province/pangea')
+        const response = await request(app).get('/provinces/pangea')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('400')
         expect($('p').text()).toEqual(
@@ -476,8 +482,8 @@ describe('Test ui responses', () => {
       '/2021',
       '/federal',
       '/federal/2021',
-      '/province/AB',
-      '/province/AB/2021',
+      '/provinces/AB',
+      '/provinces/AB/2021',
     ]
     sourceURLs.map((url) => {
       test(`should return an external source for "${url}"`, async () => {
@@ -498,19 +504,24 @@ describe('Test /province responses', () => {
     })
   })
 
-  describe('Test /province/:provinceId GET response', () => {
-    test('it should return 301', async () => {
-      const response = await request(app).get('/province/MB')
-      expect(response.statusCode).toBe(301)
-      expect(response.headers.location).toBe('/provinces/MB')
-    })
-  })
+  // should be enough
+  const provinceIds = ['AB', 'BC', 'MB', 'NB', 'QC', 'YT']
 
-  describe('Test /province/:provinceId/:year GET response', () => {
-    test('it should return 301', async () => {
-      const response = await request(app).get('/province/MB/2020')
-      expect(response.statusCode).toBe(301)
-      expect(response.headers.location).toBe('/provinces/MB/2020')
+  provinceIds.map((provinceId) => {
+    describe(`Test /province/${provinceId} GET response`, () => {
+      test('it should return 301', async () => {
+        const response = await request(app).get(`/province/${provinceId}`)
+        expect(response.statusCode).toBe(301)
+        expect(response.headers.location).toBe(`/provinces/${provinceId}`)
+      })
+    })
+
+    describe(`Test /province/${provinceId}/:year GET response`, () => {
+      test('it should return 301', async () => {
+        const response = await request(app).get(`/province/${provinceId}/2020`)
+        expect(response.statusCode).toBe(301)
+        expect(response.headers.location).toBe(`/provinces/${provinceId}/2020`)
+      })
     })
   })
 })

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -488,3 +488,29 @@ describe('Test ui responses', () => {
     })
   })
 })
+
+describe('Test /province responses', () => {
+  describe('Test /province GET response', () => {
+    test('it should return 301', async () => {
+      const response = await request(app).get('/province')
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/provinces')
+    })
+  })
+
+  describe('Test /province/:provinceId GET response', () => {
+    test('it should return 301', async () => {
+      const response = await request(app).get('/province/MB')
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/provinces/MB')
+    })
+  })
+
+  describe('Test /province/:provinceId/:year GET response', () => {
+    test('it should return 301', async () => {
+      const response = await request(app).get('/province/MB/2020')
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/provinces/MB/2020')
+    })
+  })
+})

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -30,7 +30,7 @@ describe('Test ui responses', () => {
       expect(response.statusCode).toBe(200)
     })
 
-    test('it should return the h1, title, and meta tag', async () => {
+    test('it should return the h1, title, meta tag, and canonical link', async () => {
       const response = await request(app).get('/')
       const $ = cheerio.load(response.text)
       expect($('h1 > div').text()).toMatch(/^Canada’s next holiday\u00a0is/)
@@ -41,6 +41,10 @@ describe('Test ui responses', () => {
       expect($('meta[name="description"]').attr('content')).toMatch(
         /See all \d{1,2} statutory holidays in Canada in 2020./,
       )
+      expect($('meta[name="description"]').attr('content')).toMatch(
+        /^Canada’s next stat holiday is/,
+      )
+      expect($('link[rel="canonical"]').attr('href')).toEqual('https://canada-holidays.ca/')
     })
 
     test('it should NOT return a CORS header', async () => {
@@ -50,7 +54,7 @@ describe('Test ui responses', () => {
   })
 
   describe('Test /:year responses', () => {
-    test('it should return the h1, title, and meta tag for MB in 2021', async () => {
+    test('it should return the h1, title, meta tag, and canonical link for 2021', async () => {
       const response = await request(app).get('/2021')
       const $ = cheerio.load(response.text)
       expect($('h1').text()).toEqual('Canadastatutory Holidays in 2021')
@@ -58,6 +62,7 @@ describe('Test ui responses', () => {
       expect($('meta[name="description"]').attr('content')).toMatch(
         /See all \d{1,2} statutory holidays in Canada in 2021./,
       )
+      expect($('link[rel="canonical"]').attr('href')).toEqual('https://canada-holidays.ca/2021')
     })
   })
 
@@ -68,13 +73,16 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/provinces')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('All regions in Canada')
         expect($('title').text()).toEqual('All regions in Canada — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Upcoming stat holidays for all regions in Canada. See all federal statutory holidays in Canada in 2020.',
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/provinces',
         )
       })
     })
@@ -175,7 +183,7 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical response', async () => {
         const response = await request(app).get('/provinces/MB')
         const $ = cheerio.load(response.text)
         expect($('h1 .visible').text()).toMatch(/^Manitoba’s next holiday\u00a0is/)
@@ -187,6 +195,9 @@ describe('Test ui responses', () => {
         )
         expect($('meta[name="description"]').attr('content')).toMatch(
           /See all \d{1,2} statutory holidays in Manitoba, Canada in 2020/,
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/provinces/MB',
         )
       })
     })
@@ -206,7 +217,7 @@ describe('Test ui responses', () => {
     })
 
     describe('Test /provinces/:provinceId/:year responses', () => {
-      test('it should return the h1, title, and meta tag for MB in 2021', async () => {
+      test('it should return the h1, title, meta tag, and canonical link for MB in 2021', async () => {
         const response = await request(app).get('/provinces/MB/2021')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Manitobastatutory Holidays in 2021')
@@ -215,6 +226,9 @@ describe('Test ui responses', () => {
         )
         expect($('meta[name="description"]').attr('content')).toMatch(
           /See all \d{1,2} statutory holidays in Manitoba, Canada in 2021./,
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/provinces/MB/2021',
         )
       })
     })
@@ -225,7 +239,7 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/federal')
         const $ = cheerio.load(response.text)
         expect($('h1 .visible').text()).toMatch(/^Canada’s next federal holiday\u00a0is/)
@@ -233,17 +247,23 @@ describe('Test ui responses', () => {
         expect($('meta[name="description"]').attr('content')).toMatch(
           /^Canada’s next federal stat holiday is/,
         )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/federal',
+        )
       })
     })
 
     describe('Test /federal/:year responses', () => {
-      test('it should return the h1, title, and meta tag for federal hols in 2021', async () => {
+      test('it should return the h1, title, meta tag, and canonical link for federal hols in 2021', async () => {
         const response = await request(app).get('/federal/2021')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('CanadaFederal statutory holidays in 2021')
         expect($('title').text()).toEqual('Federal statutory holidays in Canada in 2021')
         expect($('meta[name="description"]').attr('content')).toMatch(
           /See all \d{1,2} federal statutory holidays in Canada in 2021./,
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/federal/2021',
         )
       })
     })
@@ -267,7 +287,7 @@ describe('Test ui responses', () => {
         })
 
         describe('for an invalid year', () => {
-          test('it should return a 400 along with the h1, title, and meta tag', async () => {
+          test('it should return a 400 along with the h1, title, meta tag, and canonical link', async () => {
             const response = await request(app).get(`${url}/1000`)
             const $ = cheerio.load(response.text)
             expect($('h1').text()).toEqual('400')
@@ -280,6 +300,7 @@ describe('Test ui responses', () => {
             expect($('meta[name="description"]').attr('content')).toEqual(
               'Error: No holidays for the year “1000”',
             )
+            expect($('link[rel="canonical"]').length).toBe(0)
           })
 
           const INVALID_VALUES = [-1, 0, 1, 'pterodactyl']
@@ -338,7 +359,7 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/about')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('About')
@@ -346,6 +367,7 @@ describe('Test ui responses', () => {
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Check my sources, use the API, get in touch, etc.',
         )
+        expect($('link[rel="canonical"]').attr('href')).toEqual('https://canada-holidays.ca/about')
       })
     })
 
@@ -355,13 +377,16 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/feedback')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Feedback')
         expect($('title').text()).toEqual('Feedback — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Reprt a problem, tell me I’m cool, or let’s just chat even.',
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/feedback',
         )
       })
     })
@@ -372,13 +397,16 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/sources')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('All sources')
         expect($('title').text()).toEqual('All sources — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Aggregated sources for Canadian statutory holidays. Canada’s holidays vary by region and industry, so here they are collected in one place.',
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/sources',
         )
       })
     })
@@ -389,7 +417,7 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/add-holidays-to-calendar')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Add Canada’s 2020 holidays to your calendar')
@@ -398,6 +426,9 @@ describe('Test ui responses', () => {
         )
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Download Canadian holidays and import them to your Outlook, iCal, or Google Calendar. Add all Canadian statutory holidays or just for your region.',
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/add-holidays-to-calendar',
         )
       })
     })
@@ -408,13 +439,16 @@ describe('Test ui responses', () => {
         expect(response.statusCode).toBe(200)
       })
 
-      test('it should return the h1, title, and meta tag', async () => {
+      test('it should return the h1, title, meta tag, and canonical link', async () => {
         const response = await request(app).get('/do-federal-holidays-apply-to-me')
         const $ = cheerio.load(response.text)
         expect($('h1').text()).toEqual('Do federal holidays apply to me?')
         expect($('title').text()).toEqual('Do federal holidays apply to me? — Canada Holidays')
         expect($('meta[name="description"]').attr('content')).toEqual(
           'How to tell if you get federal holidays or provincial holidays in Canada.',
+        )
+        expect($('link[rel="canonical"]').attr('href')).toEqual(
+          'https://canada-holidays.ca/do-federal-holidays-apply-to-me',
         )
       })
     })
@@ -444,6 +478,7 @@ describe('Test ui responses', () => {
           expect($('meta[name="description"]').attr('content')).toEqual(
             'Error: No province with id “pangea”',
           )
+          expect($('link[rel="canonical"]').length).toBe(0)
         })
       })
       test('it should return the h1, title, and meta tag', async () => {
@@ -457,6 +492,7 @@ describe('Test ui responses', () => {
         expect($('meta[name="description"]').attr('content')).toEqual(
           'Error: No province with id “pangea”',
         )
+        expect($('link[rel="canonical"]').length).toBe(0)
       })
     })
   })
@@ -473,6 +509,7 @@ describe('Test ui responses', () => {
       expect($('h1').text()).toEqual('404')
       expect($('title').text()).toEqual('Error: 404 — Canada Holidays')
       expect($('meta[name="description"]').attr('content')).toEqual('Oopsie daisy')
+      expect($('link[rel="canonical"]').length).toBe(0)
     })
   })
 

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -99,7 +99,7 @@ router.get('/ics/:provinceId(\\w{2})', (req, res) => {
   let provinceId = req.params.provinceId
   return isProvinceId(provinceId)
     ? res.redirect(301, `/ics/${provinceId}/${getCurrentHolidayYear()}`)
-    : res.redirect(`/province/${provinceId}`) // if bad province ID, redirect will be to a 404 page
+    : res.redirect(`/provinces/${provinceId}`) // if bad province ID, redirect will be to a 404 page
 })
 
 router.get(
@@ -110,7 +110,7 @@ router.get(
     let provinceId = req.params.provinceId
     let year = ALLOWED_YEARS.find((y) => y === parseInt(req.query.year))
     if (!isProvinceId(provinceId) || !year) {
-      return res.redirect(`/province/${provinceId}`)
+      return res.redirect(`/provinces/${provinceId}`)
     }
 
     provinceId = provinceId.toUpperCase()

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -395,7 +395,7 @@ router.use(function (err, req, res, next) {
     renderPage({
       pageComponent: 'Error',
       title: `Error: ${res.statusCode} — Canada Holidays`,
-      docProps: { meta: err.message.split('.')[0], path: req.path },
+      docProps: { meta: err.message.split('.')[0], path: req.path, error: true },
       props: {
         data: {
           status: res.statusCode,

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -73,7 +73,7 @@ router.get(
   },
 )
 
-router.get('/provinces/PEI', (req, res) => res.redirect(301, '/province/PE'))
+router.get('/provinces/PEI', (req, res) => res.redirect(301, '/provinces/PE'))
 router.get('/provinces/PEI/:year', (req, res) =>
   res.redirect(301, `/provinces/PE/${req.params.year}`),
 )
@@ -273,7 +273,7 @@ router.post('/provinces', (req, res) => {
       url = '/federal'
       break
     default:
-      url = `/province/${encodeURIComponent(region.substring(0, 2).toUpperCase())}`
+      url = `/provinces/${encodeURIComponent(region.substring(0, 2).toUpperCase())}`
   }
 
   // if year is a truthy value and is whitelisted, add it to the path

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -73,10 +73,13 @@ router.get(
   },
 )
 
-router.get('/province/PEI', (req, res) => res.redirect(301, '/province/PE'))
+router.get('/provinces/PEI', (req, res) => res.redirect(301, '/province/PE'))
+router.get('/provinces/PEI/:year', (req, res) =>
+  res.redirect(301, `/provinces/PE/${req.params.year}`),
+)
 
 router.get(
-  '/province/:provinceId',
+  '/provinces/:provinceId',
   checkProvinceIdErr,
   checkRedirectYear,
   dbmw(getProvincesWithHolidays),
@@ -125,7 +128,7 @@ router.get(
 )
 
 router.get(
-  '/province/:provinceId/:year(\\d{4})',
+  '/provinces/:provinceId/:year(\\d{4})',
   param2query('year'),
   checkProvinceIdErr,
   checkYearErr,
@@ -281,7 +284,15 @@ router.post('/provinces', (req, res) => {
   return res.redirect(url)
 })
 
-router.get('/province', (req, res) => res.redirect(302, '/provinces'))
+router.get('/province', (req, res) => res.redirect(301, '/provinces'))
+
+router.get('/province/:provinceId', (req, res) => {
+  return res.redirect(301, `/provinces/${req.params.provinceId}`)
+})
+
+router.get('/province/:provinceId/:year', (req, res) => {
+  return res.redirect(301, `/provinces/${req.params.provinceId}/${req.params.year}`)
+})
 
 router.get('/do-federal-holidays-apply-to-me', (req, res) => {
   return res.send(


### PR DESCRIPTION
Noticed this a while ago: the URLs between the API and the UI and the ICS part of the app are actually inconsistent.

|                 | UI                  | API (prepended `/api/v1`)          | ICS (prepended `/ics`) |
|-----------------|---------------------|------------------------------------|------------------------|
| canada (current year)         | `/`                 | `/holidays`                        | `/2020`                |
| canada + other year   | `/2022`             | `/holidays?year=2022`              | `/2022`                |
| federal (current year)        | `/federal`          | `/holidays?federal=true`           | `/federal`             |
| federal + other year  | `/federal/2022`     | `/holidays?federal=true&year=2022` | `/federal/2022`        |
| province (current year)       | `/province/MB`      | `/provinces/MB`                    | `/MB`                  |
| province + other year | `/province/MB/2022` | `/provinces/MB?year=2022`          | `/MB/2022`             |

## Changes in this PR

This PR changes all the `/province` URLs to `/provinces`, consistent with the API, and with REST principles in general.

I added 301 redirects to the new endpoints (and wrote tests for it), and added `canonical` links in the headers. People using the site shouldn't see a difference, and search engines should be able to crawl it as before.

Additionally, I removed a bunch of lines from the `sitemap` because nobody cares about past holidays.

