### PR TITLE
Add 2023 (and make 2021 the default for the API)

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ Features:
 - Returns only federal holidays
 - Returns only national holidays
 - Returns "next" holiday for each region
-- Returns holidays for years: `2018`, `2019`, `2020`, `2021`, `2022`
+- Returns holidays for years: `2018`, `2019`, `2020`, `2021`, `2022`, `2023`
 
 Plus(!) check out all these goodies you get for ✨ free ✨:
 
@@ -54,7 +54,7 @@ None of the response object keys ever contain `null` values.
 
 There are 2 query parameters values you can use. Probably not on the root route but on others they will work.
 
-1. `?year=2018|2019|2020|2021|2022`. Defaults to current year.
+1. `?year=2018|2019|2020|2021|2022|2013`. Defaults to current year.
 2. `?federal=true|1|false|0`. `true` or `1` returns only federal holidays; `false` or `0` returns _everything but_ federal holidays.
 
 You can combine them and they will work (eg, `/api/v1/holidays?year=2021&federal=true`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.1] - 2020-12-27
+
+### Updated
+
+- Date comparison adjusts for the end of the day (UTC) before deciding whether today is still a holiday
+
+## [3.1.0] - 2020-12-26
+
+### Added
+
+- Remove redirects for "current year"
+  - Adjust canonical tags though: we want current year pages to point to the yearless links
+
+### Updated
+
+- Calculate end of the year differently for different provinces (depends on boxing day)
 
 ## [3.0.0] - 2020-11-17
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO
 
+- update sitemap
 - Service worker offline page?
 - guess location?
 - figure out about optional holidays
@@ -11,8 +12,10 @@
 
 # DONE
 
+- add 2023
 - bug: boxing day was causing problems
   - showing "next holidays" would always show new years, skipping boxing day
+  - bug: compare boxing day date for 7pm UTC
 - Change province urls to provinces to match API (so dumb that this happened)
 - download link/button has nicer calendar icon
 - add opengraph images

--- a/migrations/001-db.sql
+++ b/migrations/001-db.sql
@@ -63,8 +63,8 @@ INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Monday near April 23', 'Sain
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Monday before May 25', 'National Patriots’ Day', 'Journée nationale des patriotes');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Monday before May 25', 'Victoria Day', 'Fête de la Reine');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('June 21', 'National Indigenous Peoples Day', 'Journée nationale des peuples autochtones');
-INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Monday June 24', 'Discovery Day', 'Journée découverte');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('June 24', 'Saint-Jean-Baptiste Day', 'Saint-Jean-Baptiste / Fête nationale du Québec');
+INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Monday after June 24', 'Discovery Day', 'Journée découverte');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('July 1', 'Canada Day', 'Fête du Canada');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Monday near July 12', 'Orangemen’s Day', 'Fête des orangistes');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in August', 'Civic Holiday', 'Premier lundi d’août');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Canada Holidays API
-  version: 1.2.1
+  version: 1.3.0
   description: 'This API lists all 28 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
@@ -184,9 +184,9 @@ paths:
       parameters:
         - schema:
             type: integer
-            default: 2020
+            default: 2021
             minimum: 2018
-            maximum: 2022
+            maximum: 2023
           in: query
           description: A calendar year
           name: year
@@ -280,9 +280,9 @@ paths:
       parameters:
         - schema:
             type: integer
-            default: 2020
+            default: 2021
             minimum: 2018
-            maximum: 2022
+            maximum: 2023
           in: query
           description: A calendar year
           name: year
@@ -352,9 +352,9 @@ paths:
       parameters:
         - schema:
             type: integer
-            default: 2020
+            default: 2021
             minimum: 2018
-            maximum: 2022
+            maximum: 2023
           in: query
           description: A calendar year
           name: year
@@ -449,9 +449,9 @@ paths:
       parameters:
         - schema:
             type: integer
-            default: 2020
+            default: 2021
             minimum: 2018
-            maximum: 2022
+            maximum: 2023
           in: query
           description: A calendar year
           name: year

--- a/src/components/__tests__/ProvincePicker.test.js
+++ b/src/components/__tests__/ProvincePicker.test.js
@@ -14,7 +14,7 @@ describe('<ProvincePicker>', () => {
     const $ = renderProvincePicker()
     expect($('label').text()).toEqual('View by regionView by year')
     expect($('select').length).toBe(2)
-    expect($('select option').length).toBe(21)
+    expect($('select option').length).toBe(22)
     expect($('select option').text()).toEqual(
       `NationwideFederal──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon${ALLOWED_YEARS.join(
         '',

--- a/src/config/vars.config.js
+++ b/src/config/vars.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  ALLOWED_YEARS: [2018, 2019, 2020, 2021, 2022],
+  ALLOWED_YEARS: [2018, 2019, 2020, 2021, 2022, 2023],
   PROVINCE_IDS: ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'],
 }

--- a/src/dates/__tests__/index.test.js
+++ b/src/dates/__tests__/index.test.js
@@ -11,8 +11,8 @@ describe('Test getLiteralDate', () => {
       { str: 'Monday near April 23', iso: '2019-04-23' },
       { str: 'Monday before May 25', iso: '2019-05-20' },
       { str: 'June 21', iso: '2019-06-21' },
-      { str: 'Monday June 24', iso: '2019-06-24' },
       { str: 'June 24', iso: '2019-06-24' },
+      { str: 'Monday near June 24', iso: '2019-06-24' },
       { str: 'July 1', iso: '2019-07-01' },
       { str: 'Monday near July 12', iso: '2019-07-12' },
       { str: 'First Monday in August', iso: '2019-08-05' },
@@ -42,8 +42,8 @@ describe('Test getLiteralDate', () => {
       { str: 'Monday near April 23', iso: '2020-04-23' },
       { str: 'Monday before May 25', iso: '2020-05-18' },
       { str: 'June 21', iso: '2020-06-21' },
-      { str: 'Monday June 24', iso: '2020-06-24' },
       { str: 'June 24', iso: '2020-06-24' },
+      { str: 'Monday near June 24', iso: '2020-06-24' },
       { str: 'July 1', iso: '2020-07-01' },
       { str: 'Monday near July 12', iso: '2020-07-12' },
       { str: 'First Monday in August', iso: '2020-08-03' },
@@ -68,7 +68,7 @@ describe('Test getLiteralDate', () => {
   })
 
   describe('for 2021', () => {
-    const days2020 = [
+    const days2021 = [
       { str: 'January 1', iso: '2021-01-01' },
       { str: 'Third Monday in February', iso: '2021-02-15' },
       { str: 'Monday March 17', iso: '2021-03-17' },
@@ -77,8 +77,8 @@ describe('Test getLiteralDate', () => {
       { str: 'Monday near April 23', iso: '2021-04-23' },
       { str: 'Monday before May 25', iso: '2021-05-24' },
       { str: 'June 21', iso: '2021-06-21' },
-      { str: 'Monday June 24', iso: '2021-06-24' },
       { str: 'June 24', iso: '2021-06-24' },
+      { str: 'Monday near June 24', iso: '2021-06-24' },
       { str: 'July 1', iso: '2021-07-01' },
       { str: 'Monday near July 12', iso: '2021-07-12' },
       { str: 'First Monday in August', iso: '2021-08-02' },
@@ -91,7 +91,7 @@ describe('Test getLiteralDate', () => {
       { str: 'December 26', iso: '2021-12-26' },
     ]
 
-    days2020.map((day) => {
+    days2021.map((day) => {
       test(`returns correct 2021 ISO date string for: "${day.str}"`, () => {
         expect(getLiteralDate(day.str, 2021)).toEqual(day.iso)
       })
@@ -110,8 +110,8 @@ describe('Test getObservedDate', () => {
       { str: 'Monday near April 23', iso: '2019-04-22' },
       { str: 'Monday before May 25', iso: '2019-05-20' },
       { str: 'June 21', iso: '2019-06-21' },
-      { str: 'Monday June 24', iso: '2019-06-24' },
       { str: 'June 24', iso: '2019-06-24' },
+      { str: 'Monday near June 24', iso: '2019-06-24' },
       { str: 'July 1', iso: '2019-07-01' },
       { str: 'Monday near July 12', iso: '2019-07-15' },
       { str: 'First Monday in August', iso: '2019-08-05' },
@@ -140,8 +140,8 @@ describe('Test getObservedDate', () => {
       { str: 'Monday after Easter Day', iso: '2020-04-13' },
       { str: 'Monday near April 23', iso: '2020-04-20' },
       { str: 'Monday before May 25', iso: '2020-05-18' },
+      { str: 'Monday near June 24', iso: '2020-06-22' },
       { str: 'June 21', iso: '2020-06-21' },
-      { str: 'Monday June 24', iso: '2020-06-22' },
       { str: 'June 24', iso: '2020-06-24' },
       { str: 'July 1', iso: '2020-07-01' },
       { str: 'Monday near July 12', iso: '2020-07-13' },
@@ -167,7 +167,7 @@ describe('Test getObservedDate', () => {
   })
 
   describe('for 2021', () => {
-    const days2020 = [
+    const days2021 = [
       { str: 'January 1', iso: '2021-01-01' },
       { str: 'Third Monday in February', iso: '2021-02-15' },
       { str: 'Monday March 17', iso: '2021-03-15' },
@@ -176,7 +176,7 @@ describe('Test getObservedDate', () => {
       { str: 'Monday near April 23', iso: '2021-04-26' },
       { str: 'Monday before May 25', iso: '2021-05-24' },
       { str: 'June 21', iso: '2021-06-21' },
-      { str: 'Monday June 24', iso: '2021-06-21' },
+      { str: 'Monday near June 24', iso: '2021-06-21' },
       { str: 'June 24', iso: '2021-06-24' },
       { str: 'July 1', iso: '2021-07-01' },
       { str: 'Monday near July 12', iso: '2021-07-12' },
@@ -190,7 +190,7 @@ describe('Test getObservedDate', () => {
       { str: 'December 26', iso: '2021-12-28' },
     ]
 
-    days2020.map((day) => {
+    days2021.map((day) => {
       test(`returns correct 2021 ISO date string for: "${day.str}"`, () => {
         expect(getObservedDate(day.str, 2021)).toEqual(day.iso)
       })
@@ -198,14 +198,45 @@ describe('Test getObservedDate', () => {
   })
 
   describe('for 2022', () => {
-    const days2020 = [
+    const days2022 = [
       { str: 'December 25', iso: '2022-12-26' },
       { str: 'December 26', iso: '2022-12-27' },
     ]
 
-    days2020.map((day) => {
+    days2022.map((day) => {
       test(`returns correct 2022 ISO date string for: "${day.str}"`, () => {
         expect(getObservedDate(day.str, 2022)).toEqual(day.iso)
+      })
+    })
+  })
+
+  describe('for 2023', () => {
+    const days2023 = [
+      { str: 'January 1', iso: '2023-01-02' },
+      { str: 'Third Monday in February', iso: '2023-02-20' },
+      { str: 'Monday March 17', iso: '2023-03-13' },
+      { str: 'Friday before Easter Day', iso: '2023-04-07' },
+      { str: 'Monday after Easter Day', iso: '2023-04-10' },
+      { str: 'Monday near April 23', iso: '2023-04-24' },
+      { str: 'Monday before May 25', iso: '2023-05-22' },
+      { str: 'June 21', iso: '2023-06-21' },
+      { str: 'Monday near June 24', iso: '2023-06-26' },
+      { str: 'June 24', iso: '2023-06-26' }, // this one seems wrong
+      { str: 'July 1', iso: '2023-07-03' },
+      { str: 'Monday near July 12', iso: '2023-07-10' },
+      { str: 'First Monday in August', iso: '2023-08-07' },
+      { str: 'Third Monday in August', iso: '2023-08-21' },
+      { str: 'Third Friday in August', iso: '2023-08-18' },
+      { str: 'First Monday in September', iso: '2023-09-04' },
+      { str: 'Second Monday in October', iso: '2023-10-09' },
+      { str: 'November 11', iso: '2023-11-13' },
+      { str: 'December 25', iso: '2023-12-25' },
+      { str: 'December 26', iso: '2023-12-26' },
+    ]
+
+    days2023.map((day) => {
+      test(`returns correct 2023 ISO date string for: "${day.str}"`, () => {
+        expect(getObservedDate(day.str, 2023)).toEqual(day.iso)
       })
     })
   })

--- a/src/dates/index.js
+++ b/src/dates/index.js
@@ -1,7 +1,7 @@
 const Sugar = require('sugar-date')
 const easterDay = require('@jsbits/easter-day')
 const format = require('date-fns/format')
-const addHours = require('date-fns/addHours')
+const addMinutes = require('date-fns/addMinutes')
 const addDays = require('date-fns/addDays')
 const getISODay = require('date-fns/getISODay')
 const differenceInDays = require('date-fns/differenceInDays')
@@ -173,7 +173,8 @@ const getCurrentHolidayYear = (region = undefined) => {
     ? getObservedDate('December 26') // Boxing day
     : getObservedDate('December 25') // Christmas day
 
-  lastObservedHoliday = addHours(Sugar.Date.create(lastObservedHoliday), 23)
+  // 24 hours - 1 minute
+  lastObservedHoliday = addMinutes(Sugar.Date.create(lastObservedHoliday), 1439)
 
   // return the next year if after Boxing day
   if (isAfter(d, lastObservedHoliday)) {

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -51,7 +51,7 @@ const API = () =>
           <li>Get upcoming (“next”) holiday for each region</li>
           <li>
             Get holidays for multiple years: <code>2018</code>, <code>2019</code>,${' '}
-            <code>2020</code>, <code>2021</code>, <code>2022</code>.
+            <code>2020</code>, <code>2021</code>, <code>2022</code>, <code>2023</code>.
           </li>
         </ul>
         <${Details}

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -54,11 +54,11 @@ describe('Province page', () => {
   })
 
   test('does not render next year link', () => {
-    const $ = renderPage(2022)
+    const $ = renderPage(2023)
     expect($('h1').length).toBe(1)
     expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 28Boxing Day')
     expect($('h2').length).toBe(1)
-    expect($('h2').text()).toEqual('Canada statutory holidays in 2022')
+    expect($('h2').text()).toEqual('Canada statutory holidays in 2023')
     // check that the link to next year's holidays is NOT visible
     expect($('a.link__next-year').length).toBe(0)
   })

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -264,7 +264,7 @@ describe('Test /api responses', () => {
         })
       })
 
-      let badYears = ['2017', '2023', '1', null, undefined, false, 'orange', 'christmas']
+      let badYears = ['2017', '2024', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map((year) => {
         test(`"${year}" it should return 400 with an error message`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
@@ -272,7 +272,7 @@ describe('Test /api responses', () => {
 
           let { error } = JSON.parse(response.text)
           expect(error.message).toMatch(
-            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2022)/,
+            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2023)/,
           )
         })
       })
@@ -288,11 +288,11 @@ describe('Test /api responses', () => {
 
       expect(holiday).toMatchObject({
         id: 27,
-        date: '2020-12-26',
+        date: '2021-12-26',
         nameEn: 'Boxing Day',
         nameFr: 'Lendemain de Noël',
         federal: 1,
-        observedDate: '2020-12-28',
+        observedDate: '2021-12-28',
         provinces: expect.any(Array),
       })
     })
@@ -322,7 +322,7 @@ describe('Test /api responses', () => {
         })
       })
 
-      let badYears = ['2017', '2023', '1', null, undefined, false, 'orange', 'christmas']
+      let badYears = ['2017', '2024', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map((year) => {
         test(`"${year}" it should return 400 with an error message`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
@@ -330,7 +330,7 @@ describe('Test /api responses', () => {
 
           let { error } = JSON.parse(response.text)
           expect(error.message).toMatch(
-            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2022)/,
+            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2023)/,
           )
         })
       })

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -69,7 +69,7 @@ describe('Test ics responses', () => {
       })
     })
 
-    const BAD_YEARS = ['2016', '2017', '2023', '2024']
+    const BAD_YEARS = ['2016', '2017', '2024', '2025']
     BAD_YEARS.map((badYear) => {
       test(`it should return 302 for unsupported year "/ics/${badYear}"`, async () => {
         const response = await request(app).get(`/ics/${badYear}`)
@@ -97,7 +97,7 @@ describe('Test ics responses', () => {
         })
       })
 
-      const BAD_YEARS = ['2016', '2017', '2023', '2024']
+      const BAD_YEARS = ['2016', '2017', '2024', '2025']
       BAD_YEARS.map((badYear) => {
         test(`it should return 302 for unsupported year "/ics/${path}/${badYear}"`, async () => {
           const response = await request(app).get(`/ics/${path}/${badYear}`)

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -143,7 +143,7 @@ describe('Test ui responses', () => {
           })
         })
 
-        const BAD_YEARS = ['2016', '2017', '2023', '2024', '1', 'false', 'diplodocus']
+        const BAD_YEARS = ['2016', '2017', '2024', '2025', '1', 'false', 'diplodocus']
         BAD_YEARS.map((badYear) => {
           test(`it should return no year path for an invalid year: "${badYear}`, async () => {
             const response = await request(app).post('/provinces').send({ badYear })
@@ -322,7 +322,7 @@ describe('Test ui responses', () => {
             })
           })
 
-          const INVALID_YEARS = [2016, 2017, 2023, 2024]
+          const INVALID_YEARS = [2016, 2017, 2024, 2025]
           INVALID_YEARS.map((invalidYear) => {
             test(`it should return 400 for url: "${url}" and year: "${invalidYear}"`, async () => {
               const response = await request(app).get(`${url}/${invalidYear}`)
@@ -332,7 +332,7 @@ describe('Test ui responses', () => {
         })
 
         describe('with "year" query params', () => {
-          const INVALID_YEARS = [-1, 0, 1, 2017, 2023, 'pterodactyl']
+          const INVALID_YEARS = [-1, 0, 1, 2017, 2024, 'pterodactyl']
           INVALID_YEARS.map((invalidYear) => {
             test(`it should return 200 for url: "${url}" and a bad query param: "${invalidYear}"`, async () => {
               const response = await request(app).get(`${url}?year=${invalidYear}`)


### PR DESCRIPTION
Update the API spec to include the new max year and 2021 as the default.

Shipping it a tiny bit early but we will have to hope that nobody is too sad about it.