### PR TITLE
Show literal dates for holidays instead of your day off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2021-01-01
+
+### Updated
+
+- Show the literal dates for holidays, and observed dates underneath
+
 ## [3.2.1] - 2021-01-01
 
 ### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,199 +8,199 @@
 
 <url>
   <loc>https://canada-holidays.ca/</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/api</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/add-holidays-to-calendar</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
@@ -224,169 +224,169 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT/2020</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT/2022</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/do-federal-holidays-apply-to-me</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/sources</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT/2023</loc>
-  <lastmod>2021-01-01T07:31:56+00:00</lastmod>
+  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>

--- a/src/components/ObservedDateKey.js
+++ b/src/components/ObservedDateKey.js
@@ -1,0 +1,39 @@
+const Sugar = require('sugar-date')
+const { html } = require('../utils')
+const { displayDate } = require('../dates')
+const DateHtml = require('./DateHtml.js')
+const Details = require('./Details.js')
+const isSunday = require('date-fns/isSunday')
+
+const _getContext = ({ nameEn, provinces = [], date }) => {
+  if (nameEn === 'Boxing Day' && isSunday(Sugar.Date.create(date))) {
+    return html`<p>
+      Because Christmas is observed on Monday, ${nameEn} is pushed to the following Tuesday.
+    </p>`
+  }
+
+  if (provinces.length === 1 && ['NL', 'QC'].includes(provinces[0].id)) {
+    return html`<p>${nameEn} is observed on the Monday closest to ${displayDate(date)}.</p>`
+  }
+
+  return html`<p>When ${nameEn} falls on a weekend, it is observed the following Monday.</p>`
+}
+const ObservedDateKey = ({ holiday: { nameEn, provinces, date, observedDate } = {} }) => {
+  if (date !== observedDate) {
+    return html`
+      <${Details}
+        className="provinces"
+        summary=${html`<${DateHtml} dateString=${date} weekday=${true} //>`}
+      >
+        <div>
+          <p><em>Observed:</em> <${DateHtml} dateString=${observedDate} weekday=${true} //></p>
+          ${_getContext({ nameEn, provinces, date })}
+        </div>
+      <//>
+    `
+  }
+
+  return html`<${DateHtml} dateString=${observedDate} weekday=${true} //>`
+}
+
+module.exports = ObservedDateKey

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -44,6 +44,10 @@ const summaryRow = css`
   .key {
     font-weight: 700;
     margin-bottom: ${theme.space.xs};
+
+    summary ~ * {
+      font-weight: 400;
+    }
   }
 
   .value {

--- a/src/components/__tests__/ObservedDateKey.test.js
+++ b/src/components/__tests__/ObservedDateKey.test.js
@@ -1,0 +1,42 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils')
+
+const ObservedDateKey = require('../ObservedDateKey.js')
+
+test('ObservedDateKey displays properly', () => {
+  const holiday = { date: '2021-12-25', observedDate: '2021-12-27', nameEn: 'Christmas Day' }
+  const $ = cheerio.load(render(html` <${ObservedDateKey} holiday=${holiday} //> `))
+  expect($('summary').text()).toEqual('December 25, Saturday')
+  expect($('details div p').eq(0).text()).toEqual('Observed: December 27, Monday')
+  expect($('details div p').eq(1).text()).toEqual(
+    'When Christmas Day falls on a weekend, it is observed the following Monday.',
+  )
+})
+
+test('ObservedDateKey displays properly for Boxing day', () => {
+  const holiday = { date: '2021-12-26', observedDate: '2021-12-28', nameEn: 'Boxing Day' }
+  const $ = cheerio.load(render(html` <${ObservedDateKey} holiday=${holiday} //> `))
+  expect($('summary').text()).toEqual('December 26, Sunday')
+  expect($('details div p').eq(0).text()).toEqual('Observed: December 28, Tuesday')
+  expect($('details div p').eq(1).text()).toEqual(
+    'Because Christmas is observed on Monday, Boxing Day is pushed to the following Tuesday.',
+  )
+})
+
+test('ObservedDateKey displays properly for Saint George’s Day', () => {
+  const holiday = { date: '2021-04-23', observedDate: '2021-04-26', nameEn: 'Saint George’s Day' }
+  const $ = cheerio.load(render(html` <${ObservedDateKey} holiday=${holiday} //> `))
+  expect($('summary').text()).toEqual('April 23, Friday')
+  expect($('details div p').eq(0).text()).toEqual('Observed: April 26, Monday')
+  expect($('details div p').eq(1).text()).toEqual(
+    'When Saint George’s Day falls on a weekend, it is observed the following Monday.',
+  )
+})
+
+test('ObservedDateKey displays no details element if the observed date is the same as the calendar date', () => {
+  const holiday = { date: '2021-07-01', observedDate: '2021-07-01', nameEn: 'Canada Day' }
+  const $ = cheerio.load(render(html` <${ObservedDateKey} holiday=${holiday} //> `))
+  expect($('time').text()).toEqual('July 1, Thursday')
+  expect($('details').length).toBe(0)
+})

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -3,12 +3,13 @@ const { html, pe2pei, getProvinceIdOrFederalString } = require('../utils')
 const { theme, horizontalPadding, insideContainer } = require('../styles')
 const { ALLOWED_YEARS } = require('../config/vars.config')
 const Layout = require('../components/Layout.js')
-const DateHtml = require('../components/DateHtml.js')
 const NextHolidayBox = require('../components/NextHolidayBox.js')
 const ProvincePicker = require('../components/ProvincePicker.js')
 const SummaryTable = require('../components/SummaryTable.js')
 const CalButton = require('../components/CalButton.js')
 const NextYearLink = require('../components/NextYearLink.js')
+const ObservedDateKey = require('../components/ObservedDateKey')
+
 const { External } = require('../components/Svg.js')
 
 const styles = ({ accent = theme.color.red } = {}) => css`
@@ -45,6 +46,28 @@ const styles = ({ accent = theme.color.red } = {}) => css`
 
     .bottom-link:last-of-type {
       margin-right: ${theme.space.md};
+    }
+  }
+
+  details {
+    font-size: 1em;
+    margin-top: 0;
+
+    summary {
+      &:focus,
+      &:hover {
+        > span {
+          border-bottom: 3px solid ${accent};
+
+          @media (${theme.mq.md}) {
+            border-bottom: 5px solid ${accent};
+          }
+        }
+      }
+    }
+
+    summary ~ * {
+      color: ${theme.color.grey};
     }
   }
 `
@@ -136,7 +159,7 @@ const createRows = (holidays, federal, isCurrentYear) => {
 
   return holidays.map((holiday) => {
     const row = {
-      key: html` <${DateHtml} dateString=${holiday.observedDate} weekday=${true} //> `,
+      key: html`<${ObservedDateKey} holiday=${holiday} />`,
       value: holiday.nameEn,
       className: '',
     }

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -13,6 +13,7 @@ const getNextHoliday = (year = getCurrentHolidayYear()) => {
   return {
     id: 27,
     observedDate: `${year}-12-28`,
+    date: `${year}-12-26`,
     nameEn: 'Boxing Day',
     federal: 1,
     provinces: [getProvince()],
@@ -49,7 +50,7 @@ describe('Province page', () => {
     const $ = renderPage()
     expect($('h2#holidays-table').text()).toBe('Canada statutory holidays in 2020')
     expect($('#next-holiday-row').text()).toBe(
-      ' December 28, Tuesday Boxing Day Federal holiday, NL ',
+      'December 26, SundayObserved: December 28, TuesdayBecause Christmas is observed on Monday, Boxing Day is pushed to the following Tuesday.Boxing Day Federal holiday, NL ',
     )
   })
 


### PR DESCRIPTION
This is a pretty big step — like Apple when they removed the headphone jack from their iphones — also a courageous one. 

I've gotten a few emails over the past month about how the dates are wrong. They're not really, but it's definitely more correct to tell people that Christmas is the 25th rather than the 27th. 

Added a bit of context and an open/close little clicking element. Maybe that's shit, I don't know. Anyway, it addresses the problem.

## Screenshots

| before | new (closed) | new (open) |
|--------|--------------|------------|
|   No notion of "observed" vs literal dates     |     When closed, show the literal calendar date as well as a little triangle and an underline         |   when open, show observed date and a bit of context why it's that day.        |
|  <img width="1251" alt="Screen Shot 2021-02-06 at 1 55 05 AM" src="https://user-images.githubusercontent.com/2454380/107111617-8768cf80-681f-11eb-90ed-0c8c0e7bd123.png">   |      <img width="1251" alt="Screen Shot 2021-02-06 at 1 54 52 AM" src="https://user-images.githubusercontent.com/2454380/107111618-88016600-681f-11eb-9207-0b7d0f6c93a2.png">     |    <img width="1251" alt="Screen Shot 2021-02-06 at 1 54 45 AM" src="https://user-images.githubusercontent.com/2454380/107111615-859f0c00-681f-11eb-9ad3-ce182e635013.png">   |




