### PR TITLE
Use literal dates for the ICS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2021-04-12
+
+### Updated
+
+- Use the literal dates for holidays in the .ics files as well. Missed this earlier.
+
 ## [3.3.0] - 2021-01-01
 
 ### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/routes/ics.js
+++ b/src/routes/ics.js
@@ -21,8 +21,8 @@ const { getHolidaysWithProvinces } = require('../queries')
  */
 const formatNationalEvent = (holiday) => {
   return {
-    start: startDate(holiday.observedDate),
-    end: endDate(holiday.observedDate),
+    start: startDate(holiday.date),
+    end: endDate(holiday.date),
     title: getTitle(holiday),
     description: getNationalDescription(holiday),
     productId: '-//pcraig3//hols//EN',
@@ -36,8 +36,8 @@ const formatNationalEvent = (holiday) => {
  */
 const formatProvinceEvent = (holiday) => {
   return {
-    start: startDate(holiday.observedDate),
-    end: endDate(holiday.observedDate),
+    start: startDate(holiday.date),
+    end: endDate(holiday.date),
     title: holiday.nameEn,
     description: getProvinceDescription(holiday),
     productId: '-//pcraig3//hols//EN',


### PR DESCRIPTION
I had previously switched the display dates on the website UI to use the literal holiday dates and I also changed the API to accommodate both dates, but I had forgotten to change it for the ICS routes.

Fortunately, a hawk-eyed user noticed so I am making that change and future "holiday downloads" will go more smoothly.

Past PR: https://github.com/pcraig3/hols/pull/86