### PR TITLE
Add dates for 2024

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ Features:
 - Returns only federal holidays
 - Returns only national holidays
 - Returns "next" holiday for each region
-- Returns holidays for years: `2018`, `2019`, `2020`, `2021`, `2022`, `2023`
+- Returns holidays for years: `2018`, `2019`, `2020`, `2021`, `2022`, `2023`, `2024`
 
 Plus(!) check out all these goodies you get for ✨ free ✨:
 
@@ -54,7 +54,7 @@ None of the response object keys ever contain `null` values.
 
 There are 2 query parameters values you can use. Probably not on the root route but on others they will work.
 
-1. `?year=2018|2019|2020|2021|2022|2013`. Defaults to current year.
+1. `?year=2018|2019|2020|2021|2022|2023|2024`. Defaults to current year.
 2. `?federal=true|1|false|0`. `true` or `1` returns only federal holidays; `false` or `0` returns _everything but_ federal holidays.
 
 You can combine them and they will work (eg, `/api/v1/holidays?year=2021&federal=true`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] - 2021-08-27
+
+### Added
+
+- Added 2024 as an option
+
+### Updated
+
+- API spec updated for new year
+- Updated sitemap with new day
+
 ## [3.6.0] - 2021-07-30
 
 ### Updated

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 
 # DONE
 
+- add 2024
 - update gcloud github actions to get CD working again
 - add notification shelf for ~annoying~ informative pop-up messages
 - add Truth and Reconciliation day

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "hols",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,199 +8,199 @@
 
 <url>
   <loc>https://canada-holidays.ca/</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/api</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/add-holidays-to-calendar</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
@@ -224,169 +224,253 @@
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>daily</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT/2020</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT/2022</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/do-federal-holidays-apply-to-me</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/sources</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/MB/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/PE/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/AB/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/BC/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NB/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/ON/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/SK/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NS/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/federal/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/QC/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NT/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/NU/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://canada-holidays.ca/provinces/YT/2023</loc>
-  <lastmod>2021-02-06T07:52:20+00:00</lastmod>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/MB/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/PE/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/AB/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/BC/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NB/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/ON/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/SK/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NS/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/federal/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/QC/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NT/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/NU/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://canada-holidays.ca/provinces/YT/2024</loc>
+  <lastmod>2021-08-27T21:28:30+00:00</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.80</priority>
 </url>

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Canada Holidays API
-  version: 1.3.0
+  version: 1.3.1
   description: 'This API lists all 28 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
@@ -186,7 +186,7 @@ paths:
             type: integer
             default: 2021
             minimum: 2018
-            maximum: 2023
+            maximum: 2024
           in: query
           description: A calendar year
           name: year
@@ -282,7 +282,7 @@ paths:
             type: integer
             default: 2021
             minimum: 2018
-            maximum: 2023
+            maximum: 2024
           in: query
           description: A calendar year
           name: year
@@ -354,7 +354,7 @@ paths:
             type: integer
             default: 2021
             minimum: 2018
-            maximum: 2023
+            maximum: 2024
           in: query
           description: A calendar year
           name: year
@@ -451,7 +451,7 @@ paths:
             type: integer
             default: 2021
             minimum: 2018
-            maximum: 2023
+            maximum: 2024
           in: query
           description: A calendar year
           name: year

--- a/src/components/CalButton.js
+++ b/src/components/CalButton.js
@@ -2,7 +2,7 @@ const { html, getProvinceIdOrFederalString } = require('../utils')
 const Button = require('../components/Button.js')
 const { theme } = require('../styles')
 
-const CalButton = ({ federal, provinceId, year = 2020, className = '' }) => {
+const CalButton = ({ federal, provinceId, year = 2021, className = '' }) => {
   const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
 
   return html`

--- a/src/components/ProvincePicker.js
+++ b/src/components/ProvincePicker.js
@@ -156,7 +156,7 @@ const getProvinceNameFromId = (provinceId) => {
   }
 }
 
-const ProvincePicker = ({ provinceId, federal, year = 2020 }) => {
+const ProvincePicker = ({ provinceId, federal, year = 2021 }) => {
   const provinceIdOrFederal = getProvinceIdOrFederalString({ provinceId, federal })
   let regionName = getProvinceNameFromId(provinceId)
   regionName = regionName || (federal ? 'Federal' : 'Nationwide')

--- a/src/components/__tests__/CalButton.test.js
+++ b/src/components/__tests__/CalButton.test.js
@@ -13,8 +13,8 @@ test('CalButton renders properly with no properties', () => {
   expect($('a').length).toBe(1)
   expect($('a').text()).toEqual('Add to your calendar')
   expect($('a').attr('data-action')).toEqual('download-holidays')
-  expect($('a').attr('href')).toEqual('/ics/2020')
-  expect($('a').attr('data-label')).toEqual('download-holidays-canada-2020')
+  expect($('a').attr('href')).toEqual('/ics/2021')
+  expect($('a').attr('data-label')).toEqual('download-holidays-canada-2021')
 })
 
 test('CalButton renders properly for federal holidays for 2019', () => {

--- a/src/components/__tests__/ProvincePicker.test.js
+++ b/src/components/__tests__/ProvincePicker.test.js
@@ -14,7 +14,7 @@ describe('<ProvincePicker>', () => {
     const $ = renderProvincePicker()
     expect($('label').text()).toEqual('View by regionView by year')
     expect($('select').length).toBe(2)
-    expect($('select option').length).toBe(22)
+    expect($('select option').length).toBe(23)
     expect($('select option').text()).toEqual(
       `NationwideFederal──────────AlbertaBritish ColumbiaManitobaNew BrunswickNewfoundland and LabradorNova ScotiaNorthwest TerritoriesNunavutOntarioPrince Edward IslandQuebecSaskatchewanYukon${ALLOWED_YEARS.join(
         '',
@@ -55,9 +55,9 @@ describe('<ProvincePicker>', () => {
   })
 
   describe('year select', () => {
-    test('renders selected year as "2020" by default', () => {
+    test('renders selected year as "2021" by default', () => {
       const $ = renderProvincePicker()
-      expect($('select').eq(1).find('option[selected]').text()).toEqual('2020')
+      expect($('select').eq(1).find('option[selected]').text()).toEqual('2021')
     })
 
     ALLOWED_YEARS.map((year) => {

--- a/src/config/vars.config.js
+++ b/src/config/vars.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  ALLOWED_YEARS: [2018, 2019, 2020, 2021, 2022, 2023],
+  ALLOWED_YEARS: [2018, 2019, 2020, 2021, 2022, 2023, 2024],
   PROVINCE_IDS: ['AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'],
 }

--- a/src/dates/__tests__/index.test.js
+++ b/src/dates/__tests__/index.test.js
@@ -16,7 +16,6 @@ describe('Test getLiteralDate', () => {
       { str: 'July 1', iso: '2019-07-01' },
       { str: 'Monday near July 12', iso: '2019-07-12' },
       { str: 'First Monday in August', iso: '2019-08-05' },
-      { str: 'Third Friday in August', iso: '2019-08-16' },
       { str: 'Third Monday in August', iso: '2019-08-19' },
       { str: 'First Monday in September', iso: '2019-09-02' },
       { str: 'Second Monday in October', iso: '2019-10-14' },
@@ -48,7 +47,6 @@ describe('Test getLiteralDate', () => {
       { str: 'Monday near July 12', iso: '2020-07-12' },
       { str: 'First Monday in August', iso: '2020-08-03' },
       { str: 'Third Monday in August', iso: '2020-08-17' },
-      { str: 'Third Friday in August', iso: '2020-08-21' },
       { str: 'First Monday in September', iso: '2020-09-07' },
       { str: 'Second Monday in October', iso: '2020-10-12' },
       { str: 'November 11', iso: '2020-11-11' },
@@ -79,7 +77,6 @@ describe('Test getLiteralDate', () => {
       { str: 'Monday near July 12', iso: '2021-07-12' },
       { str: 'First Monday in August', iso: '2021-08-02' },
       { str: 'Third Monday in August', iso: '2021-08-16' },
-      { str: 'Third Friday in August', iso: '2021-08-20' },
       { str: 'First Monday in September', iso: '2021-09-06' },
       { str: 'September 30', iso: '2021-09-30' },
       { str: 'Second Monday in October', iso: '2021-10-11' },
@@ -116,7 +113,6 @@ describe('Test getObservedDate', () => {
       { str: 'July 1', iso: '2019-07-01' },
       { str: 'Monday near July 12', iso: '2019-07-15' },
       { str: 'First Monday in August', iso: '2019-08-05' },
-      { str: 'Third Friday in August', iso: '2019-08-16' },
       { str: 'Third Monday in August', iso: '2019-08-19' },
       { str: 'First Monday in September', iso: '2019-09-02' },
       { str: 'Second Monday in October', iso: '2019-10-14' },
@@ -148,7 +144,6 @@ describe('Test getObservedDate', () => {
       { str: 'Monday near July 12', iso: '2020-07-13' },
       { str: 'First Monday in August', iso: '2020-08-03' },
       { str: 'Third Monday in August', iso: '2020-08-17' },
-      { str: 'Third Friday in August', iso: '2020-08-21' },
       { str: 'First Monday in September', iso: '2020-09-07' },
       { str: 'Second Monday in October', iso: '2020-10-12' },
       { str: 'November 11', iso: '2020-11-11' },
@@ -179,7 +174,6 @@ describe('Test getObservedDate', () => {
       { str: 'Monday near July 12', iso: '2021-07-12' },
       { str: 'First Monday in August', iso: '2021-08-02' },
       { str: 'Third Monday in August', iso: '2021-08-16' },
-      { str: 'Third Friday in August', iso: '2021-08-20' },
       { str: 'First Monday in September', iso: '2021-09-06' },
       { str: 'September 30', iso: '2021-09-30' },
       { str: 'Second Monday in October', iso: '2021-10-11' },
@@ -228,7 +222,6 @@ describe('Test getObservedDate', () => {
       { str: 'Monday near July 12', iso: '2023-07-10' },
       { str: 'First Monday in August', iso: '2023-08-07' },
       { str: 'Third Monday in August', iso: '2023-08-21' },
-      { str: 'Third Friday in August', iso: '2023-08-18' },
       { str: 'First Monday in September', iso: '2023-09-04' },
       { str: 'September 30', iso: '2023-10-02' },
       { str: 'Second Monday in October', iso: '2023-10-09' },
@@ -240,6 +233,37 @@ describe('Test getObservedDate', () => {
     days2023.map((day) => {
       test(`returns correct 2023 ISO date string for: "${day.str}"`, () => {
         expect(getObservedDate(day.str, 2023)).toEqual(day.iso)
+      })
+    })
+  })
+
+  describe('for 2024', () => {
+    const days2024 = [
+      { str: 'January 1', iso: '2024-01-01' },
+      { str: 'Third Monday in February', iso: '2024-02-19' },
+      { str: 'Monday March 17', iso: '2024-03-18' },
+      { str: 'Friday before Easter Day', iso: '2024-03-29' },
+      { str: 'Monday after Easter Day', iso: '2024-04-01' },
+      { str: 'Monday near April 23', iso: '2024-04-22' },
+      { str: 'Monday before May 25', iso: '2024-05-20' },
+      { str: 'June 21', iso: '2024-06-21' },
+      { str: 'Monday near June 24', iso: '2024-06-24' },
+      { str: 'June 24', iso: '2024-06-24' }, // this one seems wrong
+      { str: 'July 1', iso: '2024-07-01' },
+      { str: 'Monday near July 12', iso: '2024-07-15' },
+      { str: 'First Monday in August', iso: '2024-08-05' },
+      { str: 'Third Monday in August', iso: '2024-08-19' },
+      { str: 'First Monday in September', iso: '2024-09-02' },
+      { str: 'September 30', iso: '2024-09-30' },
+      { str: 'Second Monday in October', iso: '2024-10-14' },
+      { str: 'November 11', iso: '2024-11-11' },
+      { str: 'December 25', iso: '2024-12-25' },
+      { str: 'December 26', iso: '2024-12-26' },
+    ]
+
+    days2024.map((day) => {
+      test(`returns correct 2024 ISO date string for: "${day.str}"`, () => {
+        expect(getObservedDate(day.str, 2024)).toEqual(day.iso)
       })
     })
   })

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -51,7 +51,8 @@ const API = () =>
           <li>Get upcoming (“next”) holiday for each region</li>
           <li>
             Get holidays for multiple years: <code>2018</code>, <code>2019</code>,${' '}
-            <code>2020</code>, <code>2021</code>, <code>2022</code>, <code>2023</code>.
+            <code>2020</code>, <code>2021</code>, <code>2022</code>, <code>2023</code>,
+            <code>2024</code>.
           </li>
         </ul>
         <${Details}

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -194,7 +194,7 @@ const Province = ({
     provinceName = 'Canada',
     provinceId,
     federal = false,
-    year = 2020,
+    year = 2021,
     source = false,
   } = {},
 }) => {

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -39,27 +39,27 @@ describe('Province page', () => {
     expect($('h1').length).toBe(1)
     expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 28Boxing Day')
     expect($('h2').length).toBe(1)
-    expect($('h2').text()).toEqual('Canada statutory holidays in 2020')
+    expect($('h2').text()).toEqual('Canada statutory holidays in 2021')
     // check the data label is lowercasing the province name
     expect($('.h1--lg a time').attr('data-label')).toEqual('next-holidays-row-link-canada')
     // check that the link to next year's holidays is visible
-    expect($('a.link__next-year').text()).toEqual('Canada statutory holidays in 2021')
+    expect($('a.link__next-year').text()).toEqual('Canada statutory holidays in 2022')
   })
 
   test('renders #next-holiday-row id', () => {
     const $ = renderPage()
-    expect($('h2#holidays-table').text()).toBe('Canada statutory holidays in 2020')
+    expect($('h2#holidays-table').text()).toBe('Canada statutory holidays in 2021')
     expect($('#next-holiday-row').text()).toBe(
       'December 26, SundayObserved: December 28, TuesdayBecause Christmas is observed on Monday, Boxing Day is pushed to the following Tuesday.Boxing Day Federal holiday, NL ',
     )
   })
 
   test('does not render next year link', () => {
-    const $ = renderPage(2023)
+    const $ = renderPage(2024)
     expect($('h1').length).toBe(1)
     expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 28Boxing Day')
     expect($('h2').length).toBe(1)
-    expect($('h2').text()).toEqual('Canada statutory holidays in 2023')
+    expect($('h2').text()).toEqual('Canada statutory holidays in 2024')
     // check that the link to next year's holidays is NOT visible
     expect($('a.link__next-year').length).toBe(0)
   })

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -264,7 +264,7 @@ describe('Test /api responses', () => {
         })
       })
 
-      let badYears = ['2017', '2024', '1', null, undefined, false, 'orange', 'christmas']
+      let badYears = ['2017', '2025', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map((year) => {
         test(`"${year}" it should return 400 with an error message`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
@@ -272,7 +272,7 @@ describe('Test /api responses', () => {
 
           let { error } = JSON.parse(response.text)
           expect(error.message).toMatch(
-            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2023)/,
+            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2024)/,
           )
         })
       })
@@ -288,7 +288,9 @@ describe('Test /api responses', () => {
 
         let { holidays } = JSON.parse(response.text)
 
-        const h = holidays.find((holiday) => holiday.nameEn === 'National Day for Truth and Reconciliation' )
+        const h = holidays.find(
+          (holiday) => holiday.nameEn === 'National Day for Truth and Reconciliation',
+        )
         expect(h.nameEn).toMatch('National Day for Truth and Reconciliation')
       })
     })
@@ -301,12 +303,13 @@ describe('Test /api responses', () => {
 
         let { holidays } = JSON.parse(response.text)
 
-        const h = holidays.find((holiday) => holiday.nameEn === 'National Day for Truth and Reconciliation' )
+        const h = holidays.find(
+          (holiday) => holiday.nameEn === 'National Day for Truth and Reconciliation',
+        )
         expect(h).toBeUndefined()
       })
     })
   })
-
 
   describe('for /api/v1/holidays/:holidayId path', () => {
     test('it should return a holiday for a good ID', async () => {
@@ -351,7 +354,7 @@ describe('Test /api responses', () => {
         })
       })
 
-      let badYears = ['2017', '2024', '1', null, undefined, false, 'orange', 'christmas']
+      let badYears = ['2017', '2025', '1', null, undefined, false, 'orange', 'christmas']
       badYears.map((year) => {
         test(`"${year}" it should return 400 with an error message`, async () => {
           const response = await request(app).get(`/api/v1/holidays?year=${year}`)
@@ -359,7 +362,7 @@ describe('Test /api responses', () => {
 
           let { error } = JSON.parse(response.text)
           expect(error.message).toMatch(
-            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2023)/,
+            /^Bad Request: request.query.year should be (integer|>= 2018|<= 2024)/,
           )
         })
       })

--- a/src/routes/__tests__/ics.test.js
+++ b/src/routes/__tests__/ics.test.js
@@ -69,7 +69,7 @@ describe('Test ics responses', () => {
       })
     })
 
-    const BAD_YEARS = ['2016', '2017', '2024', '2025']
+    const BAD_YEARS = ['2016', '2017', '2025', '2026']
     BAD_YEARS.map((badYear) => {
       test(`it should return 302 for unsupported year "/ics/${badYear}"`, async () => {
         const response = await request(app).get(`/ics/${badYear}`)
@@ -97,7 +97,7 @@ describe('Test ics responses', () => {
         })
       })
 
-      const BAD_YEARS = ['2016', '2017', '2024', '2025']
+      const BAD_YEARS = ['2016', '2017', '2025', '2026']
       BAD_YEARS.map((badYear) => {
         test(`it should return 302 for unsupported year "/ics/${path}/${badYear}"`, async () => {
           const response = await request(app).get(`/ics/${path}/${badYear}`)

--- a/src/routes/__tests__/ui.test.js
+++ b/src/routes/__tests__/ui.test.js
@@ -143,7 +143,7 @@ describe('Test ui responses', () => {
           })
         })
 
-        const BAD_YEARS = ['2016', '2017', '2024', '2025', '1', 'false', 'diplodocus']
+        const BAD_YEARS = ['2016', '2017', '2025', '2026', '1', 'false', 'diplodocus']
         BAD_YEARS.map((badYear) => {
           test(`it should return no year path for an invalid year: "${badYear}`, async () => {
             const response = await request(app).post('/provinces').send({ badYear })
@@ -322,7 +322,7 @@ describe('Test ui responses', () => {
             })
           })
 
-          const INVALID_YEARS = [2016, 2017, 2024, 2025]
+          const INVALID_YEARS = [2016, 2017, 2025, 2026]
           INVALID_YEARS.map((invalidYear) => {
             test(`it should return 400 for url: "${url}" and year: "${invalidYear}"`, async () => {
               const response = await request(app).get(`${url}/${invalidYear}`)
@@ -332,7 +332,7 @@ describe('Test ui responses', () => {
         })
 
         describe('with "year" query params', () => {
-          const INVALID_YEARS = [-1, 0, 1, 2017, 2024, 'pterodactyl']
+          const INVALID_YEARS = [-1, 0, 1, 2017, 2025, 'pterodactyl']
           INVALID_YEARS.map((invalidYear) => {
             test(`it should return 200 for url: "${url}" and a bad query param: "${invalidYear}"`, async () => {
               const response = await request(app).get(`${url}?year=${invalidYear}`)


### PR DESCRIPTION
Why not? I looked at the 404s I'm getting and some of them are looking for 2024 holidays, which let's just show them then.

Look, it says "2024" on the screenshot.

<img width="1371" alt="Screen Shot 2021-08-27 at 21 34 48" src="https://user-images.githubusercontent.com/2454380/131202131-0591e9fc-9bd0-4d88-b477-5997d0e7abd6.png">
