### PR TITLE
Display literal date with an asterisks instead of observed date

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -36,6 +36,14 @@ for (var i = 0, len = elements.length; i < len; i++) {
   });
 }
 
+// Open the details element if someone clicks the "next-holiday-link" at the top of the page
+var nextHolidayLink = document.getElementById('next-holiday-link');
+nextHolidayLink.addEventListener('click', function (e) {
+  var nextHolidayDetails = document.querySelector('#next-holiday-row details');
+  if(nextHolidayDetails) {
+    nextHolidayDetails.setAttribute('open', '');
+  }
+});
 //
 
 /*

--- a/src/components/NextHoliday.js
+++ b/src/components/NextHoliday.js
@@ -1,14 +1,32 @@
+const { css } = require('@emotion/css')
 const { html } = require('../utils')
 const DateHtml = require('./DateHtml.js')
 const { displayDate } = require('../dates')
 
+const styles = css`
+  a {
+    position: relative;
+  }
+
+  sup {
+    position: absolute;
+    top: -25%;
+  }
+`
+
+const getTitle = (nextHoliday) => {
+  return `${displayDate(nextHoliday.date)} (Observed: ${displayDate(nextHoliday.observedDate)})`
+}
+
 const screenReaderTitle = (nextHoliday, provinceName, federal) => {
   return `${provinceName}’${provinceName.slice(-1) === 's' ? '' : 's'} next ${
     federal ? 'federal ' : ''
-  }statutory holiday is ${nextHoliday.nameEn}, on ${displayDate(nextHoliday.observedDate)}.`
+  }statutory holiday is ${nextHoliday.nameEn}, on ${displayDate(nextHoliday.date)}.`
 }
 
 const NextHoliday = ({ nextHoliday, provinceName = 'Canada', federal }) => {
+  const isOffset = nextHoliday.date !== nextHoliday.observedDate
+
   return html`
     <h1>
       <span class="visuallyHidden">${screenReaderTitle(nextHoliday, provinceName, federal)}</span>
@@ -17,14 +35,18 @@ const NextHoliday = ({ nextHoliday, provinceName = 'Canada', federal }) => {
           ${provinceName}’${provinceName.slice(-1) === 's' ? '' : 's'}
           ${' '}next${' '}${federal && 'federal '}holiday${' '.replace(/ /, '\u00a0')}is
         </div>
-        <div class="h1--lg">
-          <a href="#next-holiday-row" tabindex="-1"
+        <div class="h1--lg ${styles}">
+          <a
+            id="next-holiday-link"
+            href="#next-holiday-row"
+            tabindex="-1"
+            title="${isOffset && getTitle(nextHoliday)}"
             ><${DateHtml} data-event="true" data-action="next-holidays-row-link"
             data-label=${`next-holidays-row-link-${
               federal ? 'federal' : provinceName.replace(/\s+/g, '-').toLowerCase()
             }`}
-            dateString=${nextHoliday.observedDate} //></a
-          >
+            dateString=${nextHoliday.date} //>${isOffset && html`<sup>*</sup>`}
+          </a>
         </div>
         <div class="h1--md">
           ${nextHoliday.nameEn.replace(/ /, '\u00a0').replace(/Peoples Day/, 'Peoples\u00a0Day')}

--- a/src/components/__tests__/NextHoliday.test.js
+++ b/src/components/__tests__/NextHoliday.test.js
@@ -8,10 +8,11 @@ const renderNextHoliday = (props) => {
   return cheerio.load(render(html`<${NextHoliday} ...${props} //>`))
 }
 
-const getNextHoliday = ({ federal } = {}) => {
+const getNextHoliday = ({ federal, observedDate } = {}) => {
   return {
     id: 20,
-    observedDate: '2019-08-16',
+    date: '2019-08-16',
+    observedDate: observedDate || '2019-08-16',
     nameEn: 'Gold Cup Parade Day',
     federal: federal ? 1 : 0,
     provinces: [{ id: 'PE', nameEn: 'Prince Edward Island' }],
@@ -49,10 +50,19 @@ describe('NextHoliday', () => {
 
   // renders for a federal page
   test('renders a federal-specific intro when "federal" is passed in', () => {
-    const nextHoliday = getNextHoliday()
+    const nextHoliday = getNextHoliday({ federal: true })
     const $ = renderNextHoliday({ nextHoliday, federal: true })
 
     expect($('h1').length).toBe(1)
     expect($('.h1--xs').text()).toEqual('Canada’s next federal holiday\u00a0is')
+  })
+
+  //
+  test('renders an asterisks if the observedDate is different than the literal date', () => {
+    const nextHoliday = getNextHoliday({ observedDate: '2019-08-12' })
+    const $ = renderNextHoliday({ nextHoliday })
+
+    expect($('h1').length).toBe(1)
+    expect($('.h1--lg').text()).toEqual(`${sp2nbsp('August 16*')}`)
   })
 })

--- a/src/components/__tests__/NextHolidayBox.test.js
+++ b/src/components/__tests__/NextHolidayBox.test.js
@@ -15,6 +15,7 @@ const getProvince = () => {
 const getNextHoliday = ({ federal } = {}) => {
   return {
     id: 20,
+    date: '2021-08-16',
     observedDate: '2021-08-16',
     nameEn: 'Gold Cup Parade Day',
     federal: federal ? 1 : 0,

--- a/src/pages/__tests__/Province.test.js
+++ b/src/pages/__tests__/Province.test.js
@@ -37,7 +37,7 @@ describe('Province page', () => {
   test('renders h1 and h2', () => {
     const $ = renderPage()
     expect($('h1').length).toBe(1)
-    expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 28Boxing Day')
+    expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 26*Boxing Day')
     expect($('h2').length).toBe(1)
     expect($('h2').text()).toEqual('Canada statutory holidays in 2021')
     // check the data label is lowercasing the province name
@@ -57,7 +57,7 @@ describe('Province page', () => {
   test('does not render next year link', () => {
     const $ = renderPage(2024)
     expect($('h1').length).toBe(1)
-    expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 28Boxing Day')
+    expect($('h1 .visible').text()).toEqual('Canada’s next holiday\u00a0isDecember 26*Boxing Day')
     expect($('h2').length).toBe(1)
     expect($('h2').text()).toEqual('Canada statutory holidays in 2024')
     // check that the link to next year's holidays is NOT visible


### PR DESCRIPTION
He has a point, after all.

<img width="576" alt="Screen Shot 2021-12-05 at 02 54 06" src="https://user-images.githubusercontent.com/2454380/144738458-17bc3e38-abd1-4cb7-8a00-d7a7be4370cb.png">

This PR shows the literal date, which is what people expect to see, but adds an asterisk (signalling that something is up). I also added a `title` attribute for the link, although I doubt that will matter to anyone.

| before | after |
|--------|-------|
|    seems like the wrong day, hmm    |    december 25th but there is fine print   |
|  <img width="695" alt="Screen Shot 2021-12-05 at 02 53 05" src="https://user-images.githubusercontent.com/2454380/144738493-8533e8d6-d099-423d-82a8-58fa986cf038.png">   |   <img width="695" alt="Screen Shot 2021-12-05 at 02 52 43" src="https://user-images.githubusercontent.com/2454380/144738491-1e23d34a-69f6-4485-8422-bcfcf9456d31.png">   |

