### PR TITLE
Migrate to better-sqlite3 wrapper (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # git stuff
 .git
 
+# sql stuff
+sqlite3*
+
 # project stuff
 node_modules/
 database.sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.11.1] - 2022-01-22
+
+### Fixed
+
+- Fix SQLite configuration 🤞
+
+## [3.11.0] - 2022-01-18
+
+### Fixed
+
+- Migrate away from problematic sqlite lib, use a better-sqlite3 wrapper instead
+  - This is huge: the old sqlite was breaking everything
+
 ## [3.10.2] - 2022-01-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hols",
-  "version": "3.10.2",
+  "version": "3.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hols",
-      "version": "3.10.2",
+      "version": "3.11.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.10.2",
+  "version": "3.11.1",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/config/better-sqlite3-helper.config.js
+++ b/src/config/better-sqlite3-helper.config.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+// docs: https://github.com/Kauto/better-sqlite3-helper#one-global-instance
+module.exports = {
+  path: './sqlite3.db',
+  readonly: false, // read only
+  fileMustExist: false, // throw error if database not exists
+  WAL: false, // automatically enable 'PRAGMA journal_mode = WAL'
+  migrate: {
+    // disable completely by setting `migrate: false`
+    force: 'last', // set to 'last' to automatically reapply the last migration-file
+    table: 'migration', // name of the database table that is used to keep track
+    migrationsPath: './migrations', // path of the migration-files
+  },
+}


### PR DESCRIPTION
Swapping out the problematic sqlite3 lib that I can't easily upgrade away from for a `better-sqlite3` wrapper.

My use case is fairly unconventional, so it was hard finding a way to accomplish this (directly updating `sqlite` wasn't working and `better-sqlite3` didn't support migrations). However, [`better-sqlite-helper`](https://github.com/Kauto/better-sqlite3-helper#one-global-instance) was just what I needed.

Removing `sqlite` and `bluebird`, as well as reverting to my simpler, slimmer, up-to-date Dockerfile.

💥 Boom! 💥

Update since the last one:

The last one worked locally, on locally-running containers, in tests, and in GitHub CI. However, once it made it up to Cloud Run, it took down the service. Looks like turning off WAL means that it works on Cloud Run, as described here: https://github.com/benbjohnson/litestream/issues/183