### PR TITLE
Add Alberta's optional holidays to the API

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # Canada Holidays API
 
-The <a href="https://canada-holidays.ca/api/v1/" target="_blank">Canada Holidays API</a> lists all 29 public holidays for all 13 provinces and territories in Canada, including federal holidays.
+The <a href="https://canada-holidays.ca/api/v1/" target="_blank">Canada Holidays API</a> lists all 30 public holidays for all 13 provinces and territories in Canada, including federal holidays.
 
 **👉 <a href="https://canada-holidays.ca/api/v1/" target="_blank">https://canada-holidays.ca/api/v1/</a>**
 
@@ -58,5 +58,13 @@ There are 2 query parameters values you can use. Probably not on the root route 
 2. `?federal=true|1|false|0`. `true` or `1` returns only federal holidays; `false` or `0` returns _everything but_ federal holidays.
 
 You can combine them and they will work (eg, `/api/v1/holidays?year=2021&federal=true`).
+
+##### Experimental query parameter
+
+There is 1 experimental query parameter that currently applies only to Alberta. <a href="https://www.alberta.ca/alberta-general-holidays.aspx#jumplinks-2" target="_blank">Alberta's official holidays page lists "optional" holidays</a>, so I am making them available via the API.
+
+- `?optional=true|1|false|0`. `true` or `1` returns all Alberta holidays, including optional holidays; `false` or `0` returns Alberta holidays as per usual: this is equivalent to not using "optional" at all.
+
+Optional holidays don't show up by default, so existing calls won’t be affected.
 
 That should be enough to get you started. Remember, the design goal here is _simple_.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2022-02-03
+
+### Added
+
+- Add optional holidays for Alberta to the API
+  - They don't show up by default unless you request them using a query parameter
 
 ## [3.11.2] - 2022-01-22
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 
 # DONE
 
+- Try out optional holidays for Alberta
 - Swap out problematic sqlite package for better-sqlite3
 - Update default API year to 2022, the current year
 - update the ics routes, remove the filename

--- a/migrations/001-db.sql
+++ b/migrations/001-db.sql
@@ -20,6 +20,7 @@ CREATE TABLE ProvinceHoliday (
   id INTEGER PRIMARY KEY,
   provinceId CHAR(2),
   holidayId INTEGER,
+  optional BOOLEAN DEFAULT FALSE,
   FOREIGN KEY(provinceId) REFERENCES Province(id),
   FOREIGN KEY(holidayId) REFERENCES Holiday(id)
 );
@@ -73,6 +74,7 @@ INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in August', 'Ci
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in August', 'British Columbia Day', 'Jour de Colombie-Britannique');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in August', 'New Brunswick Day', 'Jour de Nouveau Brunswick');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in August', 'Saskatchewan Day', 'Jour de Saskatchewan');
+INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in August', 'Heritage Day', 'Jour D’Héritage');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Wednesday in August', 'Regatta Day', 'Journée des régates');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('Third Monday in August', 'Discovery Day', 'Jour de la Découverte');
 INSERT INTO Holiday (date, nameEn, nameFr) VALUES ('First Monday in September', 'Labour Day', 'Fête du travail');
@@ -137,6 +139,8 @@ INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holi
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'Friday before Easter Day' AND nameEn = 'Good Friday')), 'SK');
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'Friday before Easter Day' AND nameEn = 'Good Friday')), 'YT');
 
+INSERT INTO ProvinceHoliday (holidayId, provinceId, optional) VALUES ((SELECT id FROM Holiday WHERE (date = 'Monday after Easter Day' AND nameEn = 'Easter Monday')), 'AB', 1);
+
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'Monday near April 23' AND nameEn = 'Saint George’s Day')), 'NL');
 
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'Monday before May 25' AND nameEn = 'National Patriots’ Day')), 'QC');
@@ -183,6 +187,8 @@ INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holi
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'First Monday in August' AND nameEn = 'Saskatchewan Day')), 'SK');
 
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'First Monday in August' AND nameEn = 'New Brunswick Day')), 'NB');
+
+INSERT INTO ProvinceHoliday (holidayId, provinceId, optional) VALUES ((SELECT id FROM Holiday WHERE (date = 'First Monday in August' AND nameEn = 'Heritage Day')), 'AB', 1);
 
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'First Wednesday in August' AND nameEn = 'Regatta Day')), 'NL');
 
@@ -238,6 +244,7 @@ INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holi
 
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'December 26' AND nameEn = 'Boxing Day')), 'NL');
 INSERT INTO ProvinceHoliday (holidayId, provinceId) VALUES ((SELECT id FROM Holiday WHERE (date = 'December 26' AND nameEn = 'Boxing Day')), 'ON');
+INSERT INTO ProvinceHoliday (holidayId, provinceId, optional) VALUES ((SELECT id FROM Holiday WHERE (date = 'December 26' AND nameEn = 'Boxing Day')), 'AB', 1);
 
 -- Down
 DROP TABLE ProvinceHoliday;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hols",
-  "version": "3.11.2",
+  "version": "3.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hols",
-      "version": "3.11.2",
+      "version": "3.12.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.11.2",
+  "version": "3.12.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Canada Holidays API
-  version: 1.3.2
+  version: 1.4.0
   description: 'This API lists all 30 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
@@ -29,7 +29,7 @@ paths:
                   message:
                     type: string
                     description: A welcome message
-                    example: 'Hello / Bonjour!'
+                    example: Hello / Bonjour!
                   _links:
                     type: object
                     properties:
@@ -63,7 +63,7 @@ paths:
               examples:
                 /:
                   value:
-                    message: 'Hello / Bonjour! Welcome to the Canada Holidays API / Bienvenue dans l’API canadienne des jours fériés'
+                    message: Hello / Bonjour! Welcome to the Canada Holidays API / Bienvenue dans l’API canadienne des jours fériés
                     _links:
                       self:
                         href: 'https://canada-holidays.ca/api/v1/'
@@ -202,6 +202,18 @@ paths:
           name: federal
           description: 'A boolean parameter. If true or 1, will return only federal holidays. If false or 0, will return no federal holidays.'
           allowEmptyValue: true
+        - schema:
+            type: string
+            enum:
+              - '1'
+              - '0'
+              - 'true'
+              - 'false'
+            default: 'false'
+          in: query
+          name: optional
+          description: 'A boolean parameter. If false or 0 (default), will return only Alberta’s legislated holidays. If true or 1, will return Alberta’s holidays, including optional holidays.'
+          allowEmptyValue: true
       tags:
         - holidays
   /api/v1/provinces:
@@ -287,6 +299,18 @@ paths:
           description: A calendar year
           name: year
           allowEmptyValue: true
+        - schema:
+            type: string
+            enum:
+              - '1'
+              - '0'
+              - 'true'
+              - 'false'
+            default: 'false'
+          in: query
+          name: optional
+          description: 'A boolean parameter. If false or 0 (default), will return only Alberta’s legislated holidays. If true or 1, will return Alberta’s holidays, including optional holidays.'
+          allowEmptyValue: true
       description: Returns provinces and territories in Canada. Each province or territory lists its associated holidays.
   '/api/v1/provinces/{provinceId}':
     get:
@@ -358,6 +382,18 @@ paths:
           in: query
           description: A calendar year
           name: year
+          allowEmptyValue: true
+        - schema:
+            type: string
+            default: 'false'
+            enum:
+              - '1'
+              - '0'
+              - 'true'
+              - 'false'
+          in: query
+          name: optional
+          description: 'A boolean parameter. If false or 0 (default), will return only Alberta’s legislated holidays. If true or 1, will return Alberta’s holidays, including optional holidays.'
           allowEmptyValue: true
       tags:
         - provinces
@@ -456,6 +492,18 @@ paths:
           description: A calendar year
           name: year
           allowEmptyValue: true
+        - schema:
+            type: string
+            default: 'false'
+            enum:
+              - '1'
+              - '0'
+              - 'true'
+              - 'false'
+          in: query
+          name: optional
+          description: 'A boolean parameter. If false or 0 (default), will return provinces for which this is a legislated holiday. If true or 1, will return provinces which optionally celebrate this holiday.'
+          allowEmptyValue: true
       tags:
         - holidays
 components:
@@ -465,25 +513,31 @@ components:
       type: object
       description: 'A Canadian holiday. Includes a name, the literal date of the holiday, the observed date of the holiday (ie, accommodating for weekends), and a list of regions that observe this holiday.'
       x-examples:
-        /holidays/27:
+        /holidays/30?optional=true:
           holiday:
-            id: 27
-            date: '2020-12-26'
+            id: 30
+            date: '2022-12-26'
             nameEn: Boxing Day
             nameFr: Lendemain de Noël
             federal: 1
-            observedDate: '2020-12-28'
+            observedDate: '2022-12-27'
             provinces:
               - id: NL
                 nameEn: Newfoundland and Labrador
                 nameFr: Terre-Neuve-et-Labrador
                 sourceLink: 'https://gist.github.com/pcraig3/81dff348ddf52777c9f918c3032531bd'
-                sourceEn: Clarification on public holidays in Newfoundland
+                sourceEn: Public holidays in Newfoundland
               - id: 'ON'
                 nameEn: Ontario
                 nameFr: Ontario
                 sourceLink: 'https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays'
-                sourceEn: Public holidays
+                sourceEn: Ontario Public holidays
+              - id: AB
+                nameEn: Alberta
+                nameFr: Alberta
+                sourceLink: 'https://www.alberta.ca/alberta-general-holidays.aspx#toc-1'
+                sourceEn: General holidays in Alberta
+                optional: 1
       properties:
         id:
           type: integer
@@ -500,12 +554,12 @@ components:
           type: string
           description: English name
           example: Louis Riel Day
-        name Fr:
+        nameFr:
           type: string
           description: French name
           example: Journée Louis Riel
         federal:
-          type: number
+          type: integer
           description: Whether this holiday is observed by federally-regulated industries.
           enum:
             - 1
@@ -520,6 +574,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Province'
+        optional:
+          type: integer
+          format: binary
+          enum:
+            - 1
+          description: 'Whether this is a province-wide statutory holiday, or one that is optional for employers.'
+      required:
+        - id
+        - date
+        - nameEn
+        - nameFr
+        - federal
+        - observedDate
     Province:
       title: Province
       type: object
@@ -631,6 +698,18 @@ components:
           type: string
           description: Name of reference page with public holidays for this region
           example: What are the general holidays in Manitoba?
+        optional:
+          type: integer
+          description: Whether this province optionally observes a given holiday.
+          format: binary
+          enum:
+            - 1
+      required:
+        - id
+        - nameFr
+        - nameEn
+        - sourceLink
+        - sourceEn
     Error:
       title: Error
       type: object

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Canada Holidays API
   version: 1.3.2
-  description: 'This API lists all 29 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
+  description: 'This API lists all 30 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
     url: 'https://canada-holidays.ca/api'
@@ -389,7 +389,7 @@ paths:
           type: integer
           example: 2
           minimum: 1
-          maximum: 29
+          maximum: 30
         name: holidayId
         in: path
         required: true
@@ -490,7 +490,7 @@ components:
           description: Primary key for a holiday
           example: 2
           minimum: 1
-          maximum: 29
+          maximum: 30
         date:
           type: string
           description: 'ISO date: the literal date of the holiday'

--- a/src/pages/API.js
+++ b/src/pages/API.js
@@ -30,7 +30,7 @@ const API = () =>
         <p>
           The ${' '}<a href="https://canada-holidays.ca/api/v1/" target="_blank"
             >Canada Holidays API</a
-          >${' '}lists all 29 public holidays for all 13 provinces and territories in Canada,
+          >${' '}lists all 30 public holidays for all 13 provinces and territories in Canada,
           including federal holidays.
         </p>
         <p>

--- a/src/queries/__tests__/index.test.js
+++ b/src/queries/__tests__/index.test.js
@@ -1,24 +1,24 @@
-const { _parseFederal } = require('../index')
+const { _parseBoolean } = require('../index')
 
-describe('Test _parseFederal', () => {
+describe('Test _parseBoolean', () => {
   const yesFederal = ['1', 'true', 'TRUE', 'TrUe']
-  yesFederal.map(val => {
+  yesFederal.map((val) => {
     test(`returns 1 for value: “${val}”`, () => {
-      expect(_parseFederal(val)).toBe(1)
+      expect(_parseBoolean(val)).toBe(1)
     })
   })
 
   const noFederal = ['0', 'false', 'FALSE', 'FalSe']
-  noFederal.map(val => {
+  noFederal.map((val) => {
     test(`returns 0 for value: “${val}”`, () => {
-      expect(_parseFederal(val)).toBe(0)
+      expect(_parseBoolean(val)).toBe(0)
     })
   })
 
   const invalidFederal = ['2', '-1', 'one', 'Yes', 't', 'f', '']
-  invalidFederal.map(val => {
+  invalidFederal.map((val) => {
     test(`returns null for value: “${val}”`, () => {
-      expect(_parseFederal(val)).toBe(null)
+      expect(_parseBoolean(val)).toBe(null)
     })
   })
 })

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -86,7 +86,7 @@ const getNextHoliday = (provinces) => {
   })
 }
 
-const getProvincesWithHolidays = (db, { provinceId, year, optional = false }) => {
+const getProvincesWithHolidays = (db, { provinceId, year, optional }) => {
   const provincesObj = array2Obj(getProvinces(db, { provinceId }))
   Object.values(provincesObj).map((p) => (p.holidays = []))
 
@@ -96,6 +96,9 @@ const getProvincesWithHolidays = (db, { provinceId, year, optional = false }) =>
 
   phs.map((ph) => {
     if (provincesObj[ph.provinceId]) {
+      if (ph.optional) {
+        holidaysObj[ph.holidayId]['optional'] = 1
+      }
       provincesObj[ph.provinceId].holidays.push(holidaysObj[ph.holidayId])
     }
   })
@@ -106,7 +109,7 @@ const getProvincesWithHolidays = (db, { provinceId, year, optional = false }) =>
   return Object.values(provincesObj)
 }
 
-const getHolidaysWithProvinces = (db, { holidayId, federal, year, optional = false }) => {
+const getHolidaysWithProvinces = (db, { holidayId, federal, year, optional }) => {
   const holidaysObj = array2Obj(getHolidays(db, { holidayId, federal, year }))
   Object.values(holidaysObj).map((h) => (h.provinces = []))
 
@@ -116,6 +119,9 @@ const getHolidaysWithProvinces = (db, { holidayId, federal, year, optional = fal
 
   phs.map((ph) => {
     if (holidaysObj[ph.holidayId]) {
+      if (ph.optional) {
+        provincesObj[ph.provinceId]['optional'] = 1
+      }
       holidaysObj[ph.holidayId].provinces.push(provincesObj[ph.provinceId])
     }
   })

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -305,13 +305,13 @@ describe('Test /api responses', () => {
 
   describe('for /api/v1/holidays/:holidayId path', () => {
     test('it should return a holiday for a good ID', async () => {
-      const response = await request(app).get('/api/v1/holidays/29')
+      const response = await request(app).get('/api/v1/holidays/30')
       expect(response.statusCode).toBe(200)
 
       let { holiday } = JSON.parse(response.text)
 
       expect(holiday).toMatchObject({
-        id: 29,
+        id: 30,
         date: `${currentYear}-12-26`,
         nameEn: 'Boxing Day',
         nameFr: 'Lendemain de Noël',
@@ -328,7 +328,7 @@ describe('Test /api responses', () => {
       let { error } = JSON.parse(response.text)
 
       expect(error).toMatchObject({
-        message: 'Bad Request: request.params.holidayId should be <= 29',
+        message: 'Bad Request: request.params.holidayId should be <= 30',
         status: response.statusCode,
         timestamp: expect.any(String),
       })

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -198,6 +198,24 @@ describe('Test /api responses', () => {
         })
       })
     })
+
+    describe('with optional holidays', () => {
+      test('it should NOT return optional holidays for a good ID: "AB"', async () => {
+        const response = await request(app).get('/api/v1/provinces/AB?optional=false')
+        expect(response.statusCode).toBe(200)
+
+        let { province } = JSON.parse(response.text)
+        expect(province.holidays.length).toBe(9)
+      })
+
+      test('it should return optional holidays for a good ID: "AB"', async () => {
+        const response = await request(app).get('/api/v1/provinces/AB?optional=true')
+        expect(response.statusCode).toBe(200)
+
+        let { province } = JSON.parse(response.text)
+        expect(province.holidays.length).toBe(12)
+      })
+    })
   })
 
   describe('for /api/v1/holidays path', () => {
@@ -304,7 +322,7 @@ describe('Test /api responses', () => {
   })
 
   describe('for /api/v1/holidays/:holidayId path', () => {
-    test('it should return a holiday for a good ID', async () => {
+    test('it should return a holiday for a good ID: 30', async () => {
       const response = await request(app).get('/api/v1/holidays/30')
       expect(response.statusCode).toBe(200)
 
@@ -318,6 +336,24 @@ describe('Test /api responses', () => {
         federal: 1,
         observedDate: `${currentYear}-12-27`,
         provinces: expect.any(Array),
+      })
+    })
+
+    describe('with optional provinces', () => {
+      test('it should NOT return optional provinces for a good ID: 30', async () => {
+        const response = await request(app).get('/api/v1/holidays/30?optional=false')
+        expect(response.statusCode).toBe(200)
+
+        let { holiday } = JSON.parse(response.text)
+        expect(holiday.provinces.length).toBe(2)
+      })
+
+      test('it should return optional provinces for a good ID: 30', async () => {
+        const response = await request(app).get('/api/v1/holidays/30?optional=true')
+        expect(response.statusCode).toBe(200)
+
+        let { holiday } = JSON.parse(response.text)
+        expect(holiday.provinces.length).toBe(3)
       })
     })
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -45,6 +45,7 @@ const dbmw = (cb) => {
       provinceId: req.params.provinceId,
       federal: _parseFederal(req),
       year: _parseYear(req),
+      optional: req.query.optional,
     }
 
     try {


### PR DESCRIPTION
# Summary

After getting this request from a number of people, I'm going to add [Alberta's optional holidays](https://www.alberta.ca/alberta-general-holidays.aspx#jumplinks-2) to the API and make them available via a query parameter. 

Optional holidays for Alberta are:
- Easter Monday: April 18
- Heritage Day: August 1
- Boxing Day: December 26

Note that they won't be available yet in the UI or as ICS files.

Please let me know in the comments if this all makes sense. I'm planning to merge this in the next few days. 

No existing API calls will be affected.

## Optional holidays by adding `?optional=true`

Here are the docs I've written:

> There is 1 experimental query parameter that currently applies only to Alberta. [Alberta's official holidays page lists "optional" holidays](https://www.alberta.ca/alberta-general-holidays.aspx#jumplinks-2), so I am making those available via the API.

> - `?optional=true|1|false|0`. `true` or `1` returns all Alberta holidays, including optional holidays; `false` or `0` returns Alberta holidays as per usual: this is equivalent to not using "optional" at all.

> Optional holidays don't show up by default, so existing calls won’t be affected.


## Notes 

The tricky thing to model around this was that the "optional" status of a holiday isn't a property of the holiday itself, but it is a property of the _relationship_ between a holiday and a province. 

For example, "Boxing Day" is a required holiday in Ontario and for federal employees, but is _optional_ for Alberta. This means that we can't say that Boxing Day is intrinsically "optional", it only becomes optional when Alberta is implicated.

- When returning all holidays for Alberta, show Boxing Day with an additional property: `optional: 1`
- When returning all provinces that observe Boxing Day, show Alberta with an additional property: `optional: 1`

That last scenario is a little weird, as there's no such thing as an "optional" province, but it seemed the most intuitive way to go about it.

Note also that `optional` is `1` instead of `true`. This is in line with our other boolean parameter: `federal`.

A province's `nextHoliday` key can include an optional holiday as the 'next upcoming' when optional holidays are being returned.

## Example responses 

<details>

<summary> Example response for: /v1/provinces/AB?optional=true</summary>

```json
{
   "province":{
      "id":"AB",
      "nameEn":"Alberta",
      "nameFr":"Alberta",
      "sourceLink":"https://www.alberta.ca/alberta-general-holidays.aspx#toc-1",
      "sourceEn":"General holidays in Alberta",
      "holidays":[
         {
            "id":1,
            "date":"2022-01-01",
            "nameEn":"New Year’s Day",
            "nameFr":"Jour de l’An",
            "federal":1,
            "observedDate":"2022-01-03"
         },
         {
            "id":4,
            "date":"2022-02-21",
            "nameEn":"Family Day",
            "nameFr":"Fête de la famille",
            "federal":0,
            "observedDate":"2022-02-21"
         },
         {
            "id":7,
            "date":"2022-04-15",
            "nameEn":"Good Friday",
            "nameFr":"Vendredi saint",
            "federal":1,
            "observedDate":"2022-04-15"
         },
         {
            "id":8,
            "date":"2022-04-18",
            "nameEn":"Easter Monday",
            "nameFr":"Lundi de Pâques",
            "federal":1,
            "observedDate":"2022-04-18",
            "optional":1
         },
         {
            "id":11,
            "date":"2022-05-23",
            "nameEn":"Victoria Day",
            "nameFr":"Fête de la Reine",
            "federal":1,
            "observedDate":"2022-05-23"
         },
         {
            "id":15,
            "date":"2022-07-01",
            "nameEn":"Canada Day",
            "nameFr":"Fête du Canada",
            "federal":1,
            "observedDate":"2022-07-01"
         },
         {
            "id":22,
            "date":"2022-08-01",
            "nameEn":"Heritage Day",
            "nameFr":"Jour D’Héritage",
            "federal":0,
            "observedDate":"2022-08-01",
            "optional":1
         },
         {
            "id":25,
            "date":"2022-09-05",
            "nameEn":"Labour Day",
            "nameFr":"Fête du travail",
            "federal":1,
            "observedDate":"2022-09-05"
         },
         {
            "id":27,
            "date":"2022-10-10",
            "nameEn":"Thanksgiving",
            "nameFr":"Action de grâce",
            "federal":1,
            "observedDate":"2022-10-10"
         },
         {
            "id":28,
            "date":"2022-11-11",
            "nameEn":"Remembrance Day",
            "nameFr":"Jour du Souvenir",
            "federal":1,
            "observedDate":"2022-11-11"
         },
         {
            "id":29,
            "date":"2022-12-25",
            "nameEn":"Christmas Day",
            "nameFr":"Noël",
            "federal":1,
            "observedDate":"2022-12-26"
         },
         {
            "id":30,
            "date":"2022-12-26",
            "nameEn":"Boxing Day",
            "nameFr":"Lendemain de Noël",
            "federal":1,
            "observedDate":"2022-12-27",
            "optional":1
         }
      ],
      "nextHoliday":{
         "id":4,
         "date":"2022-02-21",
         "nameEn":"Family Day",
         "nameFr":"Fête de la famille",
         "federal":0,
         "observedDate":"2022-02-21"
      }
   }
}
```

</details>

<details>
<summary> Example response for: /v1/holidays/30?optional=true</summary>

```json
{
   "holiday":{
      "id":30,
      "date":"2022-12-26",
      "nameEn":"Boxing Day",
      "nameFr":"Lendemain de Noël",
      "federal":1,
      "observedDate":"2022-12-27",
      "provinces":[
         {
            "id":"NL",
            "nameEn":"Newfoundland and Labrador",
            "nameFr":"Terre-Neuve-et-Labrador",
            "sourceLink":"https://gist.github.com/pcraig3/81dff348ddf52777c9f918c3032531bd",
            "sourceEn":"Public holidays in Newfoundland"
         },
         {
            "id":"ON",
            "nameEn":"Ontario",
            "nameFr":"Ontario",
            "sourceLink":"https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays",
            "sourceEn":"Ontario Public holidays"
         },
         {
            "id":"AB",
            "nameEn":"Alberta",
            "nameFr":"Alberta",
            "sourceLink":"https://www.alberta.ca/alberta-general-holidays.aspx#toc-1",
            "sourceEn":"General holidays in Alberta",
            "optional":1
         }
      ]
   }
}
```

</details>