### PR TITLE
Add some spacing to lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.1] - 2022-02-06
+
+### Updated
+
+- Add spacing to list elements
+- Add top spacing to h1 on "provinces" page
+- Remove some whitespace from the Summary Table titles
+
 ## [3.12.0] - 2022-02-03
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,17 @@
 # TODO
 
+- Add optional holidays for Alberta
+  - To the UI
+  - To ICS downloads
 - different versions of "federal" holidays
-- figure out about optional holidays
 - add years to dates on years pages?
 - make API to return CSV format
   - page for CSV downloads
 
 # DONE
 
-- Try out optional holidays for Alberta
+- Add optional holidays for Alberta
+  - In the API
 - Swap out problematic sqlite package for better-sqlite3
 - Update default API year to 2022, the current year
 - update the ics routes, remove the filename

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hols",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hols",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -42,17 +42,16 @@ const summaryRow = css`
   }
 
   .key {
-    font-weight: 700;
     margin-bottom: ${theme.space.xs};
 
-    summary ~ * {
-      font-weight: 400;
+    time {
+      font-weight: 700;
     }
   }
 
   .value {
     white-space: pre-wrap;
-    margin-bottom: ${theme.space.md};
+    padding-bottom: ${theme.space.md};
   }
 
   @media (${theme.mq.lg}) {

--- a/src/pages/AddHolidays.js
+++ b/src/pages/AddHolidays.js
@@ -71,13 +71,15 @@ const AddHolidays = ({ data: { provinces, year } }) => {
       <${Content} className=${headerStyles}>
         <h1>Add Canadian holidays to your calendar</h1>
         <p>There are 2 ways to add holidays to your calendar:</p>
-        <ul>
-          <li>Adding a “remote calendar” URL that will keep itself updated.</li>
-          <li>
-            Downloading the holidays locally and importing them into your preferred calendar
-            program.
-          </li>
-        </ul>
+        <div>
+          <ul>
+            <li>Adding a “remote calendar” URL that will keep itself updated.</li>
+            <li>
+              Downloading the holidays locally and importing them into your preferred calendar
+              program.
+            </li>
+          </ul>
+        </div>
 
         <${SummaryTable}
           title="Stream Canadian statutory holidays"

--- a/src/pages/FederallyRegulated.js
+++ b/src/pages/FederallyRegulated.js
@@ -31,7 +31,7 @@ const FederallyRegulated = () =>
         <p>
           Approximately 6% of Canadians work in federally regulated industries. Some examples are:
         </p>
-        <ul>
+        <ul class="no-space">
           <li>banks</li>
           <li>airlines</li>
           <li>post offices</li>

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -122,9 +122,7 @@ const titleStyles = css`
 `
 
 const getTitleString = (provinceName, federal, year) => {
-  return `
-    ${provinceName}${federal ? ' federal' : ''} statutory holidays in ${year}
-  `
+  return `${provinceName}${federal ? ' federal' : ''} statutory holidays in ${year}`
 }
 
 const createRows = (holidays, federal, isCurrentYear) => {
@@ -170,9 +168,9 @@ const createRows = (holidays, federal, isCurrentYear) => {
     }
 
     if (isCurrentYear) {
-      row.className = holiday.observedDate < today ? 'past' : 'upcoming'
+      row.className += holiday.observedDate < today ? ' past' : ' upcoming'
 
-      if (nextFound === false && row.className === 'upcoming') {
+      if (nextFound === false && row.className.includes('upcoming')) {
         // add "next-holiday-row" id to first upcoming holiday
         row.id = 'next-holiday-row'
         nextFound = true

--- a/src/pages/Provinces.js
+++ b/src/pages/Provinces.js
@@ -6,10 +6,6 @@ const Layout = require('../components/Layout.js')
 const Details = require('../components/Details.js')
 
 const styles = css`
-  h1 {
-    margin: ${theme.space.xs} 0 ${theme.space.xl} 0;
-  }
-
   div {
     margin-bottom: ${theme.space.md};
   }

--- a/src/styles.js
+++ b/src/styles.js
@@ -93,7 +93,8 @@ const contentPageStyles = css`
     }
   }
 
-  ul {
+  ul,
+  ol {
     padding-left: ${theme.space.md};
 
     @media (${theme.mq.sm}) {
@@ -102,6 +103,16 @@ const contentPageStyles = css`
 
     @media (${theme.mq.md}) {
       padding-left: ${theme.space.xl};
+    }
+
+    li {
+      padding-bottom: ${theme.space.xxs};
+    }
+
+    &.no-space {
+      li {
+        padding-bottom: 0;
+      }
     }
   }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -40,7 +40,7 @@ const dbmw = (cb) => {
     }
 
     // allow query parameters or url parameters to be passed in
-    let options = {
+    const options = {
       holidayId: req.params.holidayId,
       provinceId: req.params.provinceId,
       federal: _parseFederal(req),


### PR DESCRIPTION
This PR makes some very minimal changes.

- Add spacing to list elements
- Add top spacing to h1 on "provinces" page
- Remove some whitespace from the Summary Table titles

### Screenshot

We can see the header moves down and the list items have more room to breathe.

| before | after |
|--------|-------|
|  <img width="1495" alt="Screen Shot 2022-02-06 at 23 57 14" src="https://user-images.githubusercontent.com/2454380/152726985-50743517-2ead-4d3b-9fac-4b576254a394.png">    |  <img width="1495" alt="Screen Shot 2022-02-06 at 23 57 08" src="https://user-images.githubusercontent.com/2454380/152726978-00f49f0e-d345-40c8-b2a8-f09fd09e3153.png">   |

