### PR TITLE
Optional holidays for BC, part 2

### DIFF
--- a/API.md
+++ b/API.md
@@ -59,11 +59,11 @@ There are 2 query parameters values you can use. Probably not on the root route 
 
 You can combine them and they will work (eg, `/api/v1/holidays?year=2021&federal=true`).
 
-##### Experimental query parameter
+##### 'Optional' query parameter
 
-There is 1 experimental query parameter that currently applies only to Alberta. <a href="https://www.alberta.ca/alberta-general-holidays.aspx#jumplinks-2" target="_blank">Alberta's official holidays page lists "optional" holidays</a>, so I am making them available via the API.
+There is 1 optional query parameter that currently applies only to Alberta and British Columbia. <a href="https://www.alberta.ca/alberta-general-holidays.aspx#jumplinks-2" target="_blank">Alberta's official holidays page lists "optional" holidays</a>, and <a href="https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/msp/claim-submission-payment/designated-holidays-and-close-off-dates" target="_blank">British Columbia's</a> is pretty close as well, so I am making them available via the API.
 
-- `?optional=true|1|false|0`. `true` or `1` returns all Alberta holidays, including optional holidays; `false` or `0` returns Alberta holidays as per usual: this is equivalent to not using "optional" at all.
+- `?optional=true|1|false|0`. `true` or `1` returns all Alberta and BC holidays, including optional holidays; `false` or `0` returns Alberta and BC holidays as per usual: this is equivalent to not using "optional" at all.
 
 Optional holidays don't show up by default, so existing calls won’t be affected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional holidays for BC to the API
   - Again, they don't show up by default unless you request them using a query parameter
 
+### Updated
+
+- Add optional holidays to UI for BC
 
 ## [3.14.0] - 2022-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0] - 2022-04-23
+
+### Added
+
+- Add optional holidays for BC to the API
+  - Again, they don't show up by default unless you request them using a query parameter
+
+
 ## [3.14.0] - 2022-04-22
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 
 # DONE
 
+- Optional holidays for BC
 - Add 2017, 2025, 2026
 - Add optional holidays for Alberta
   - In the API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.13.1",
+  "version": "3.15.0",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/reference/Canada-Holidays-API.v1.yaml
+++ b/reference/Canada-Holidays-API.v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Canada Holidays API
-  version: 1.4.1
+  version: 1.5.0
   description: 'This API lists all 30 public holidays for all 13 provinces and territories in Canada, including federal holidays.'
   contact:
     name: Paul Craig
@@ -212,7 +212,7 @@ paths:
             default: 'false'
           in: query
           name: optional
-          description: 'A boolean parameter. If false or 0 (default), will return only Alberta’s legislated holidays. If true or 1, will return Alberta’s holidays, including optional holidays.'
+          description: 'A boolean parameter. If false or 0 (default), will return only legislated holidays. If true or 1, will return optional holidays from Alberta and BC.'
           allowEmptyValue: true
       tags:
         - holidays
@@ -309,7 +309,7 @@ paths:
             default: 'false'
           in: query
           name: optional
-          description: 'A boolean parameter. If false or 0 (default), will return only Alberta’s legislated holidays. If true or 1, will return Alberta’s holidays, including optional holidays.'
+          description: 'A boolean parameter. If false or 0 (default), will return only legislated holidays. If true or 1, will return optional holidays from Alberta and BC.'
           allowEmptyValue: true
       description: Returns provinces and territories in Canada. Each province or territory lists its associated holidays.
   '/api/v1/provinces/{provinceId}':
@@ -393,7 +393,7 @@ paths:
               - 'false'
           in: query
           name: optional
-          description: 'A boolean parameter. If false or 0 (default), will return only Alberta’s legislated holidays. If true or 1, will return Alberta’s holidays, including optional holidays.'
+          description: 'A boolean parameter (AB and BC only). If false or 0 (default), will return only legislated holidays. If true or 1, will return optional holidays from Alberta and BC.'
           allowEmptyValue: true
       tags:
         - provinces

--- a/src/pages/OptionalHolidays.js
+++ b/src/pages/OptionalHolidays.js
@@ -33,7 +33,11 @@ const OptionalHolidays = () =>
           </ul>
         </aside>
 
-        <p>Back to <a href="/provinces/AB">Alberta holidays</a>.</p>
+        <p>Back to:</p>
+        <ul>
+          <li><a href="/provinces/AB">Alberta holidays</a></li>
+          <li><a href="/provinces/BC">British Columbia holidays</a></li>
+        </ul>
 
         <h2>How are statutory holidays different from optional holidays?</h2>
         <p>

--- a/src/routes/__tests__/api.test.js
+++ b/src/routes/__tests__/api.test.js
@@ -215,6 +215,22 @@ describe('Test /api responses', () => {
         let { province } = JSON.parse(response.text)
         expect(province.holidays.length).toBe(12)
       })
+
+      test('it should NOT return optional holidays for a good ID: "BC"', async () => {
+        const response = await request(app).get('/api/v1/provinces/BC?optional=false')
+        expect(response.statusCode).toBe(200)
+
+        let { province } = JSON.parse(response.text)
+        expect(province.holidays.length).toBe(10)
+      })
+
+      test('it should return optional holidays for a good ID: "BC"', async () => {
+        const response = await request(app).get('/api/v1/provinces/BC?optional=true')
+        expect(response.statusCode).toBe(200)
+
+        let { province } = JSON.parse(response.text)
+        expect(province.holidays.length).toBe(13)
+      })
     })
   })
 
@@ -353,7 +369,7 @@ describe('Test /api responses', () => {
         expect(response.statusCode).toBe(200)
 
         let { holiday } = JSON.parse(response.text)
-        expect(holiday.provinces.length).toBe(3)
+        expect(holiday.provinces.length).toBe(4)
       })
     })
 

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -8,7 +8,7 @@ const {
   checkProvinceIdErr,
   checkYearErr,
   checkRedirectYear,
-  albertaOptionalTrue,
+  optionalTrue,
   param2query,
   nextHoliday,
   pe2pei,
@@ -80,7 +80,7 @@ router.get(
   '/provinces/:provinceId',
   checkProvinceIdErr,
   checkRedirectYear,
-  albertaOptionalTrue,
+  optionalTrue,
   dbmw(getProvincesWithHolidays),
   (req, res) => {
     const {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -113,11 +113,11 @@ const checkRedirectYear = (req, res, next) => {
   next()
 }
 
-// middleware to add "optional=true" where provinceId is Alberta, if no query param is set
-const albertaOptionalTrue = (req, res, next) => {
+// middleware to add "optional=true" where provinceId is Alberta or BC, if no query param is set
+const optionalTrue = (req, res, next) => {
   const provinceId = req.params.provinceId
 
-  if (provinceId === 'AB' && req.query.optional === undefined) {
+  if ((provinceId === 'AB' || provinceId === 'BC') && req.query.optional === undefined) {
     req.query.optional = 'true'
   }
 
@@ -266,7 +266,7 @@ module.exports = {
   checkProvinceIdErr,
   checkYearErr,
   checkRedirectYear,
-  albertaOptionalTrue,
+  optionalTrue,
   getCanonical,
   param2query,
   nextHoliday,


### PR DESCRIPTION
# Summary

Follow up to #118, and which resolves #117.

This PR updates the API docs and the version number. 

Optional holidays for BC are:

- Easter Monday: April 18
- Truth and Reconciliation Day: September 30
- Boxing Day: December 26

Source: https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/msp/claim-submission-payment/designated-holidays-and-close-off-dates

Same as the way that the Alberta calls work, using the `optional` parameter.

## Screenshots

| before | after |
|--------|-------|
|  no optional holidays      |   yes optional holidays (I've highlighted them)     |
|   <img width="1200" alt="Screen Shot 2022-04-23 at 09 58 12" src="https://user-images.githubusercontent.com/2454380/164889856-2a6c1af8-fe10-42c9-8d31-ddb8b9796e15.png">   |   <img width="1200" alt="Screen Shot 2022-04-23 at 09 58 09" src="https://user-images.githubusercontent.com/2454380/164889854-f253cfd5-0aed-43d2-ad5c-e9d390019138.png"> |



## Example calls 

<details>
<summary>
Example response for BC holidays: v1/provinces/BC?optional=true
</summary>

```json
{
  "province": {
    "id": "BC",
    "nameEn": "British Columbia",
    "nameFr": "Colombie-Britannique",
    "sourceLink": "https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays#body",
    "sourceEn": "Statutory Holidays in British Columbia",
    "holidays": [
      {
        "id": 1,
        "date": "2022-01-01",
        "nameEn": "New Year’s Day",
        "nameFr": "Jour de l’An",
        "federal": 1,
        "observedDate": "2022-01-03"
      },
      {
        "id": 4,
        "date": "2022-02-21",
        "nameEn": "Family Day",
        "nameFr": "Fête de la famille",
        "federal": 0,
        "observedDate": "2022-02-21"
      },
      {
        "id": 7,
        "date": "2022-04-15",
        "nameEn": "Good Friday",
        "nameFr": "Vendredi saint",
        "federal": 1,
        "observedDate": "2022-04-15"
      },
      {
        "id": 8,
        "date": "2022-04-18",
        "nameEn": "Easter Monday",
        "nameFr": "Lundi de Pâques",
        "federal": 1,
        "observedDate": "2022-04-18",
        "optional": 1
      },
      {
        "id": 11,
        "date": "2022-05-23",
        "nameEn": "Victoria Day",
        "nameFr": "Fête de la Reine",
        "federal": 1,
        "observedDate": "2022-05-23"
      },
      {
        "id": 15,
        "date": "2022-07-01",
        "nameEn": "Canada Day",
        "nameFr": "Fête du Canada",
        "federal": 1,
        "observedDate": "2022-07-01"
      },
      {
        "id": 19,
        "date": "2022-08-01",
        "nameEn": "British Columbia Day",
        "nameFr": "Jour de Colombie-Britannique",
        "federal": 0,
        "observedDate": "2022-08-01"
      },
      {
        "id": 25,
        "date": "2022-09-05",
        "nameEn": "Labour Day",
        "nameFr": "Fête du travail",
        "federal": 1,
        "observedDate": "2022-09-05"
      },
      {
        "id": 26,
        "date": "2022-09-30",
        "nameEn": "National Day for Truth and Reconciliation",
        "nameFr": "Journée nationale de la vérité et de la réconciliation",
        "federal": 1,
        "observedDate": "2022-09-30",
        "optional": 1
      },
      {
        "id": 27,
        "date": "2022-10-10",
        "nameEn": "Thanksgiving",
        "nameFr": "Action de grâce",
        "federal": 1,
        "observedDate": "2022-10-10"
      },
      {
        "id": 28,
        "date": "2022-11-11",
        "nameEn": "Remembrance Day",
        "nameFr": "Jour du Souvenir",
        "federal": 1,
        "observedDate": "2022-11-11"
      },
      {
        "id": 29,
        "date": "2022-12-25",
        "nameEn": "Christmas Day",
        "nameFr": "Noël",
        "federal": 1,
        "observedDate": "2022-12-26"
      },
      {
        "id": 30,
        "date": "2022-12-26",
        "nameEn": "Boxing Day",
        "nameFr": "Lendemain de Noël",
        "federal": 1,
        "observedDate": "2022-12-27",
        "optional": 1
      }
    ],
    "nextHoliday": {
      "id": 11,
      "date": "2022-05-23",
      "nameEn": "Victoria Day",
      "nameFr": "Fête de la Reine",
      "federal": 1,
      "observedDate": "2022-05-23"
    }
  }
}
```

</details>

<details>
<summary>
Example response for Truth and Reconciliation day: v1/holidays/26?optional=true
</summary>

```json

{
  "holiday": {
    "id": 26,
    "date": "2022-09-30",
    "nameEn": "National Day for Truth and Reconciliation",
    "nameFr": "Journée nationale de la vérité et de la réconciliation",
    "federal": 1,
    "observedDate": "2022-09-30",
    "provinces": [
      {
        "id": "BC",
        "nameEn": "British Columbia",
        "nameFr": "Colombie-Britannique",
        "sourceLink": "https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays#body",
        "sourceEn": "Statutory Holidays in British Columbia",
        "optional": 1
      }
    ]
  }
}

```

</details>

