### PR TITLE
Improve the print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.1] - 2022-12-06
+
+### Updated
+
+- Updated print styles for holidays pages
+  - Added back in Holidays logo
+  - Removed accent colours, "details" triangles, underlines, and bottom link
+  - Real holidays are solid black, optiona holidays are grey
+
 ## [3.18.0] - 2022-11-23
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 
 # DONE
 
+- Improve print styles
 - Fix speakable stuff
 - Fix the google dataset stuff
 - Fix the sitemap

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hols",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hols",
-      "version": "3.18.0",
+      "version": "3.18.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/components/NextYearLink.js
+++ b/src/components/NextYearLink.js
@@ -24,7 +24,7 @@ const getLink = ({ provinceId, year, federal }) => {
 
 const NextYearLink = ({ provinceName, provinceId, year, federal }) => {
   return html`
-    <div class=${styles}>
+    <div class=${`hidden-print ${styles}`}>
       <a
         href=${getLink({ provinceId, year, federal })}
         class="link__next-year right-arrow"

--- a/src/headStyles.js
+++ b/src/headStyles.js
@@ -99,20 +99,36 @@ module.exports = {
     }
 
     body {
-      font-size: 11px;
+      font-size: 12px;
       line-height: 1.2;
       font-family: sans-serif;
       color: black;
+      padding: 0px 10px;
+    }
+
+    header .links,
+    #next-holiday,
+    .bottom-link,
+    .hidden-print {
+      display: none !important;
     }
 
     header,
-    #next-holiday,
-    .bottom-link {
-      display: none;
-    }
-
     main section {
       padding: 0 !important;
+    }
+
+    header nav {
+      padding-top: 10px;
+      padding-bottom: 16px;
+    }
+
+    header nav > div:first-of-type > a {
+      color: black !important;
+    }
+
+    header nav > div:first-of-type > a > svg > path {
+      fill: black !important;
     }
 
     header nav,
@@ -127,7 +143,7 @@ module.exports = {
     section h2 {
       margin: 0 !important;
       padding-top: 0 !important;
-      padding-bottom: 24px !important;
+      padding-bottom: 16px !important;
     }
 
     section h1 ~ h2 {
@@ -139,12 +155,40 @@ module.exports = {
       margin-bottom: 0 !important;
     }
 
-    dt.key,
-    dd.value,
-    dd.value2 {
+    dl dt.key,
+    dl dd.value,
+    dl dd.value2 {
       width: 33% !important;
       padding: 8px 8px 8px 0 !important;
       border-width: 1px !important;
+    }
+
+    dl > div:not(.optional) dt.key,
+    dl > div:not(.optional) dd.value,
+    dl > div:not(.optional) dd.value2 {
+        opacity: 1 !important;
+    }
+
+    dl > div.optional dt.key,
+    dl > div.optional dd.value,
+    dl > div.optional dd.value2 {
+        opacity: 0.6;
+    }
+
+    #next-holiday-row > dt.key {
+      color: black;
+    }
+
+    details summary {
+      list-style: none;
+    }
+
+    details summary::-webkit-details-marker {
+      display:none;
+    }
+
+    details summary > span {
+      text-decoration: none !important;
     }
   }
 `,

--- a/src/pages/Province.js
+++ b/src/pages/Province.js
@@ -226,7 +226,7 @@ const Province = ({
                 </h2>
                 <div>
                   <${CalButton} provinceId=${provinceId} federal=${federal} year=${year}
-                  query=${'cd=true'} className=${'ghost'} //>
+                  query=${'cd=true'} className=${'ghost hidden-print'} //>
                 </div>
               </div>`}
             <//>


### PR DESCRIPTION
Print styles look pretty different across browsers, so there's only so much you can do with them really.

However, let's focus on the positive. [I did a previous PR to fix the print styles](https://github.com/pcraig3/hols/pull/19), but since then I have added in a lot of new elements and have been getting some weird results. Here's a before/after PDF output from Edge. 

| before | after |
|--------|-------|
|   <img width="1546" alt="Screenshot 2022-12-06 at 3 24 07 PM" src="https://user-images.githubusercontent.com/2454380/206015187-a5ce029e-fddb-4c10-b881-a653a6446785.png">  |  <img width="1546" alt="Screenshot 2022-12-06 at 3 24 00 PM" src="https://user-images.githubusercontent.com/2454380/206015186-1372c04c-a0bf-40a0-9437-9c9b06ab0c45.png">    |



Changes:

- Added "Canada Holidays" logo
- Removed "Add to calendar" button
- No more arrow or underline for "details" holidays 
- No more overlapping "next year's holidays" link
- No more accent colours
- Stat holidays are black, optional holidays are grey