### PR TITLE
Upgrade to GA4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.2] - 2022-12-06
+
+### Updated
+
+- Added GA4, since the other one is getting depped
+  - Previous implementation is still there for now, but will be removed eventually
+
 ## [3.18.1] - 2022-12-06
 
 ### Updated

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 
 # DONE
 
+- Update to GA4, otherwise we get cut off
 - Improve print styles
 - Fix speakable stuff
 - Fix the google dataset stuff

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hols",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hols",
-      "version": "3.18.1",
+      "version": "3.18.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hols",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "description": "hols for cans: canada holidays api and canada holidays frontend",
   "main": "index.js",
   "author": "pcraig3",

--- a/src/config/csp.config.js
+++ b/src/config/csp.config.js
@@ -2,19 +2,26 @@
 // docs: https://helmetjs.github.io/docs/csp/
 module.exports = {
   defaultSrc: ["'self'"],
-  connectSrc: ["'self'", 'https://www.google-analytics.com'],
+  connectSrc: [
+    "'self'",
+    'https://*.google-analytics.com',
+    'https://*.analytics.google.com',
+    'https://*.googletagmanager.com',
+  ],
   baseUri: ["'none'"],
   fontSrc: ["'self'", 'https://fonts.gstatic.com'],
   formAction: ["'self'"],
   frameAncestors: ["'none'"],
-  imgSrc: ["'self'", 'data:', 'https://www.google-analytics.com'],
+  imgSrc: ["'self'", 'data:', 'https://*.google-analytics.com', 'https://*.googletagmanager.com'],
   scriptSrc: [
     "'self'",
     "'sha256-vmyqYv8llK+DTbFomsM0G2wJMexFKZZPejzpvzQF+ek='",
     "'sha256-Wezgm/yRorRVzqbr6vDdLOJEGKDTVKRuWZ2Yh53e/EU='",
     "'sha256-/PhlWtWSFKGpnQswrM5AJwZ6WsgKO5Bn3J8jgWZfT4Q='",
+    "'sha256-tXEM7Y+7ipjlM5ZP3uzDVkEnZfYHvPFf2Aux3uiH5ho='",
     'https://www.google-analytics.com',
     'https://static.cloudflareinsights.com',
+    'https://*.googletagmanager.com',
   ],
   styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
 }

--- a/src/headStyles.js
+++ b/src/headStyles.js
@@ -20,6 +20,30 @@ module.exports = {
       })
     }
   }, false);`,
+  ga4: `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BHZ9J5CD89');
+
+    document.addEventListener('DOMContentLoaded', function() {
+
+      const eventLinks = document.querySelectorAll('a[data-event="true"]');
+      for (let i = 0; i < eventLinks.length; i++) {
+        eventLinks[i].addEventListener('click', function (event) {
+          // 'this' is the element that the event handler is set on (otherwise, e.target is sometimes the children)
+          gtag('event', 'click', {
+            event_category: this.tagName,
+            event_action: this.dataset.action,
+            event_label: this.dataset.label,
+          });
+        })
+      }
+
+    });
+  `,
+  ga4Id: 'G-BHZ9J5CD89',
   fontStyles: `
   /* generated with https://google-webfonts-helper.herokuapp.com/fonts/gothic-a1?subsets=latin */
   /* gothic-a1-300 - latin */

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -3,7 +3,7 @@ const render = require('preact-render-to-string')
 const { html, metaIfSHA, getOgImagePath, getCanonical } = require('../utils')
 const { breadcrumb, speakable } = require('../utils/richSnippets')
 const { theme, visuallyHidden } = require('../styles')
-const { fontStyles, printStyles, ga } = require('../headStyles')
+const { fontStyles, printStyles, ga, ga4, ga4Id } = require('../headStyles')
 
 const document = ({
   title,
@@ -62,6 +62,13 @@ const document = ({
           process.env.NODE_ENV === 'production'
             ? `<script>${ga}</script>
               <script async src='https://www.google-analytics.com/analytics.js'></script>`
+            : ''
+        }
+
+        ${
+          process.env.NODE_ENV === 'production'
+            ? `<script async src="https://www.googletagmanager.com/gtag/js?id=${ga4Id}"></script>
+              <script>${ga4}</script>`
             : ''
         }
 


### PR DESCRIPTION
The original GA (Universal Analytics) is being retired in about 6 months, so let's swap it over.

This PR introduces GA4 without removing the prior implementation, so we should see some overlap for a while but I can get rid of the previous version eventually.

This PR has no visual aid but I just want to make sure all the tests pass.

Resources that I found useful:
- https://developers.google.com/analytics/devguides/collection/ga4/events?client_type=gtag
- https://www.thyngster.com/tracking-google-analytics-4-events-using-data-attributes
- https://javascript.info/bubbling-and-capturing